### PR TITLE
Rion object read write

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,17 @@ You can then edit the TION data, save it, and convert it back to RION.
 
 # RION vs. ION
 RION was first released under the name ION, but since its release Amazon has released its own binary data format
-named ION. Therefore we have renamed Nanosai ION to RION to clearly distinguish it from Amazon ION. Actually,
-Nanosai ION and Amazon ION are similar in structure, but we believe Nanosai ION has a few advantages over Amazon ION,
-especially when working with the data in its raw form (binary form). However, going forward we will call Nanosai ION
-for RION.
+named ION. To avoid confusiong we are currently using the term "Raw Internet Object Notation" (RION)
+to clearly distinguish it from Amazon ION. Actually, Nanosai ION and Amazon ION are similar in structure,
+but we believe Nanosai ION has a few advantages over Amazon ION, especially when working with the data in its raw form
+(binary form).
+
+Note: RION is our current "working title", but we may change the name in the future. However, the most important is not
+the name of the format, but it's capabilities!
 
 
 
 <a name="maven-dependency"></a>
-
 # Maven Dependency
 
 If you want to use RION Ops with Maven, the Maven dependency for RION Ops looks like this:
@@ -112,7 +114,7 @@ If you want to use RION Ops with Maven, the Maven dependency for RION Ops looks 
     <dependency>
         <groupId>com.nanosai</groupId>
         <artifactId>rion-ops</artifactId>
-        <version>0.5.3</version>
+        <version>0.7.0</version>
     </dependency>
 
 Remember to substitute the version with the version of RION Ops you want to use. See the RION Ops version history in
@@ -125,6 +127,7 @@ the next section.
 
 | Version | Java Version | Change |
 |---------|--------------|--------|
+| 0.7.0   | Java 8+      | RionObjectWriter and RionObjectReader + support classes added. |
 | 0.6.0   | Java 8+      | RionToHexConverter added. Minor enhancements to RionWriter for writing Array and Table fields. |
 | 0.5.3   | Java 8+      | Bug fix of reading UTF-8 fields into Java Strings (issue #3) |
 | 0.5.2   | Java 8+      | First release |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nanosai</groupId>
     <artifactId>rion-ops</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <packaging>jar</packaging>
 
     <name>RION Ops for Java</name>

--- a/src/main/java/com/nanosai/rionops/rion/RionUtil.java
+++ b/src/main/java/com/nanosai/rionops/rion/RionUtil.java
@@ -29,13 +29,13 @@ public class RionUtil {
     }
 
     /*
-    public static Map<IonKeyFieldKey, IIonFieldReader> createFieldReaders(
+    public static Map<RionKeyFieldKey, IRionFieldReader> createFieldReaders(
             Field[] fields,
-            IIonObjectReaderConfigurator configurator,
-            Map<Field, IIonFieldReader> existingFieldReaders) {
+            IRionObjectReaderConfigurator configurator,
+            Map<Field, IRionFieldReader> existingFieldReaders) {
 
-        IonFieldReaderConfiguration          fieldConfiguration = new IonFieldReaderConfiguration();
-        Map<IonKeyFieldKey, IIonFieldReader> fieldReaderMap     = new HashMap<>();
+        RionFieldReaderConfiguration          fieldConfiguration = new RionFieldReaderConfiguration();
+        Map<RionKeyFieldKey, IRionFieldReader> fieldReaderMap     = new HashMap<>();
 
         for(int i=0; i < fields.length; i++){
 
@@ -47,9 +47,9 @@ public class RionUtil {
             configurator.configure(fieldConfiguration);
 
             if(existingFieldReaders.containsKey(fields[i])){
-                IIonFieldReader fieldReader = existingFieldReaders.get(fields[i]);
+                IRionFieldReader fieldReader = existingFieldReaders.get(fields[i]);
                 try {
-                    fieldReaderMap.put(new IonKeyFieldKey(fieldConfiguration.alias.getBytes("UTF-8")), fieldReader); //todo this is wrong - should be IonKeyFieldKey - except those are not unique to classes...
+                    fieldReaderMap.put(new RionKeyFieldKey(fieldConfiguration.alias.getBytes("UTF-8")), fieldReader); //todo this is wrong - should be RionKeyFieldKey - except those are not unique to classes...
                 } catch (UnsupportedEncodingException e) {
                     e.printStackTrace();
                     //todo better exception handling, although UTF-8 is a known encoding.
@@ -59,18 +59,18 @@ public class RionUtil {
 
 
             if (fieldConfiguration.include) {
-                IIonFieldReader fieldReader = IonUtil.createFieldReader(fields[i], configurator);
+                IRionFieldReader fieldReader = IonUtil.createFieldReader(fields[i], configurator);
 
                 existingFieldReaders.put(fields[i], fieldReader);
 
-                if(fieldReader instanceof IonFieldReaderObject){
-                    ((IonFieldReaderObject) fieldReader).generateFieldReaders(configurator, existingFieldReaders);
-                } else if(fieldReader instanceof IonFieldReaderTable){
-                    ((IonFieldReaderTable) fieldReader).generateFieldReaders(configurator, existingFieldReaders);
+                if(fieldReader instanceof RionFieldReaderObject){
+                    ((RionFieldReaderObject) fieldReader).generateFieldReaders(configurator, existingFieldReaders);
+                } else if(fieldReader instanceof RionFieldReaderTable){
+                    ((RionFieldReaderTable) fieldReader).generateFieldReaders(configurator, existingFieldReaders);
                 }
 
                 try {
-                    fieldReaderMap.put(new IonKeyFieldKey(fieldConfiguration.alias.getBytes("UTF-8")), fieldReader);
+                    fieldReaderMap.put(new RionKeyFieldKey(fieldConfiguration.alias.getBytes("UTF-8")), fieldReader);
                 } catch (UnsupportedEncodingException e) {
                     e.printStackTrace();
                     //todo throw exception - but will never happen since UTF-8 is a known encoding.
@@ -81,16 +81,16 @@ public class RionUtil {
     }
 
 
-    public static IIonFieldWriter[] createFieldWriters(
-            Field[] fields, IIonObjectWriterConfigurator configurator,
-            Map<Field, IIonFieldWriter> existingFieldWriters) {
-        List<IIonFieldWriter> fieldWritersTemp = new ArrayList<>();
+    public static IRionFieldWriter[] createFieldWriters(
+            Field[] fields, IRionObjectWriterConfigurator configurator,
+            Map<Field, IRionFieldWriter> existingFieldWriters) {
+        List<IRionFieldWriter> fieldWritersTemp = new ArrayList<>();
 
-        IonFieldWriterConfiguration fieldConfiguration = new IonFieldWriterConfiguration();
+        RionFieldWriterConfiguration fieldConfiguration = new RionFieldWriterConfiguration();
 
         for(int i=0; i < fields.length; i++){
             if(existingFieldWriters.containsKey(fields[i])){
-                IIonFieldWriter fieldWriter = existingFieldWriters.get(fields[i]);
+                IRionFieldWriter fieldWriter = existingFieldWriters.get(fields[i]);
                 fieldWritersTemp.add(fieldWriter);
                 continue;
             }
@@ -103,21 +103,21 @@ public class RionUtil {
             configurator.configure(fieldConfiguration);
 
             if(fieldConfiguration.include){
-                IIonFieldWriter fieldWriter =
+                IRionFieldWriter fieldWriter =
                         IonUtil.createFieldWriter(fields[i], fieldConfiguration.alias, configurator, existingFieldWriters);
 
                 existingFieldWriters.put(fields[i], fieldWriter);
 
-                if(fieldWriter instanceof IonFieldWriterObject){
-                    ((IonFieldWriterObject) fieldWriter).generateFieldWriters(configurator, existingFieldWriters);
-                } else if(fieldWriter instanceof IonFieldWriterTable){
-                    ((IonFieldWriterTable) fieldWriter).generateFieldWriters(configurator, existingFieldWriters);
+                if(fieldWriter instanceof RionFieldWriterObject){
+                    ((RionFieldWriterObject) fieldWriter).generateFieldWriters(configurator, existingFieldWriters);
+                } else if(fieldWriter instanceof RionFieldWriterTable){
+                    ((RionFieldWriterTable) fieldWriter).generateFieldWriters(configurator, existingFieldWriters);
                 }
                 fieldWritersTemp.add(fieldWriter);
             }
         }
 
-        IIonFieldWriter[] fieldWriters = new IIonFieldWriter[fieldWritersTemp.size()];
+        IRionFieldWriter[] fieldWriters = new IRionFieldWriter[fieldWritersTemp.size()];
 
         for(int i=0, n=fieldWritersTemp.size(); i < n; i++){
             fieldWriters[i] = fieldWritersTemp.get(i);
@@ -126,63 +126,63 @@ public class RionUtil {
         return fieldWriters;
     }
 
-    public static IIonFieldWriter createFieldWriter(Field field, String alias, IIonObjectWriterConfigurator configurator, Map<Field, IIonFieldWriter> existingFieldWriters){
+    public static IRionFieldWriter createFieldWriter(Field field, String alias, IRionObjectWriterConfigurator configurator, Map<Field, IRionFieldWriter> existingFieldWriters){
         field.setAccessible(true); //allows access to private fields, and supposedly speeds up reflection...  ?
         Class fieldType = field.getType();
 
         if(boolean.class.equals(fieldType)){
-            return new IonFieldWriterBoolean(field, alias);
+            return new RionFieldWriterBoolean(field, alias);
         }
         if(byte.class.equals(fieldType)){
-            return new IonFieldWriterByte(field, alias);
+            return new RionFieldWriterByte(field, alias);
         }
         if(short.class.equals(fieldType)){
-            return new IonFieldWriterShort(field, alias);
+            return new RionFieldWriterShort(field, alias);
         }
         if(int.class.equals(fieldType)){
-            return new IonFieldWriterInt(field, alias);
+            return new RionFieldWriterInt(field, alias);
         }
         if(long.class.equals(fieldType)){
-            return new IonFieldWriterLong(field, alias);
+            return new RionFieldWriterLong(field, alias);
         }
         if(float.class.equals(fieldType)){
-            return new IonFieldWriterFloat(field, alias);
+            return new RionFieldWriterFloat(field, alias);
         }
         if(double.class.equals(fieldType)){
-            return new IonFieldWriterDouble(field, alias);
+            return new RionFieldWriterDouble(field, alias);
         }
         if(String.class.equals(fieldType)){
-            return new IonFieldWriterString(field, alias);
+            return new RionFieldWriterString(field, alias);
         }
         if(Calendar.class.equals(fieldType)){
-            return new IonFieldWriterCalendar(field, alias);
+            return new RionFieldWriterCalendar(field, alias);
         }
         if(GregorianCalendar.class.equals(fieldType)){
-            return new IonFieldWriterCalendar(field, alias);
+            return new RionFieldWriterCalendar(field, alias);
         }
         if(fieldType.isArray()){
             if(byte.class.equals(fieldType.getComponentType())){
-                return new IonFieldWriterArrayByte(field, alias);
+                return new RionFieldWriterArrayByte(field, alias);
             }
             if(short.class.equals(fieldType.getComponentType())){
-                return new IonFieldWriterArrayShort(field, alias);
+                return new RionFieldWriterArrayShort(field, alias);
             }
             if(int.class.equals(fieldType.getComponentType())){
-                return new IonFieldWriterArrayInt(field, alias);
+                return new RionFieldWriterArrayInt(field, alias);
             }
             if(long.class.equals(fieldType.getComponentType())){
-                return new IonFieldWriterArrayLong(field, alias);
+                return new RionFieldWriterArrayLong(field, alias);
             }
             if(float.class.equals(fieldType.getComponentType())){
-                return new IonFieldWriterArrayFloat(field, alias);
+                return new RionFieldWriterArrayFloat(field, alias);
             }
             if(double.class.equals(fieldType.getComponentType())){
-                return new IonFieldWriterArrayDouble(field, alias);
+                return new RionFieldWriterArrayDouble(field, alias);
             }
-            return new IonFieldWriterTable(field, alias);
+            return new RionFieldWriterTable(field, alias);
         }
 
-        return new IonFieldWriterObject(field, alias);
+        return new RionFieldWriterObject(field, alias);
     }
 
      */
@@ -190,69 +190,69 @@ public class RionUtil {
 
     //todo remove this ?
     /*
-    public static IIonFieldReader createFieldReader(Field field){
+    public static IRionFieldReader createFieldReader(Field field){
         return createFieldReader(field, null);
     }
     */
 
     /*
-    public static IIonFieldReader createFieldReader(Field field, IIonObjectReaderConfigurator configurator){
+    public static IRionFieldReader createFieldReader(Field field, IRionObjectReaderConfigurator configurator){
 
         field.setAccessible(true); //allows access to private fields, and supposedly speeds up reflection...  ?
         Class fieldType = field.getType();
 
         if(boolean.class.equals(fieldType)){
-            return new IonFieldReaderBoolean(field);
+            return new RionFieldReaderBoolean(field);
         }
         if(byte.class.equals(fieldType)){
-            return new IonFieldReaderByte(field);
+            return new RionFieldReaderByte(field);
         }
         if(short.class.equals(fieldType)){
-            return new IonFieldReaderShort(field);
+            return new RionFieldReaderShort(field);
         }
         if(int.class.equals(fieldType)){
-            return new IonFieldReaderInt(field);
+            return new RionFieldReaderInt(field);
         }
         if(long.class.equals(fieldType)){
-            return new IonFieldReaderLong(field);
+            return new RionFieldReaderLong(field);
         }
         if(float.class.equals(fieldType)){
-            return new IonFieldReaderFloat(field);
+            return new RionFieldReaderFloat(field);
         }
         if(double.class.equals(fieldType)){
-            return new IonFieldReaderDouble(field);
+            return new RionFieldReaderDouble(field);
         }
         if(String.class.equals(fieldType)){
-            return new IonFieldReaderString(field);
+            return new RionFieldReaderString(field);
         }
         if(Calendar.class.equals(fieldType)){
-            return new IonFieldReaderCalendar(field);
+            return new RionFieldReaderCalendar(field);
         }
         if(GregorianCalendar.class.equals(fieldType)){
-            return new IonFieldReaderCalendar(field);
+            return new RionFieldReaderCalendar(field);
         }
         if(fieldType.isArray()){
             if(byte.class.equals(fieldType.getComponentType())){
-                return new IonFieldReaderArrayByte(field);
+                return new RionFieldReaderArrayByte(field);
             }
             if(short.class.equals(fieldType.getComponentType())){
-                return new IonFieldReaderArrayShort(field);
+                return new RionFieldReaderArrayShort(field);
             }
             if(int.class.equals(fieldType.getComponentType())){
-                return new IonFieldReaderArrayInt(field);
+                return new RionFieldReaderArrayInt(field);
             }
             if(long.class.equals(fieldType.getComponentType())){
-                return new IonFieldReaderArrayLong(field);
+                return new RionFieldReaderArrayLong(field);
             }
             if(float.class.equals(fieldType.getComponentType())){
-                return new IonFieldReaderArrayFloat(field);
+                return new RionFieldReaderArrayFloat(field);
             }
             if(double.class.equals(fieldType.getComponentType())){
-                return new IonFieldReaderArrayDouble(field);
+                return new RionFieldReaderArrayDouble(field);
             }
-            return new IonFieldReaderTable(field, configurator);
+            return new RionFieldReaderTable(field, configurator);
         } else {
-            return new IonFieldReaderObject(field, configurator);
+            return new RionFieldReaderObject(field, configurator);
         }
 
         //todo support object field writer

--- a/src/main/java/com/nanosai/rionops/rion/read/object/IRionFieldReader.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/IRionFieldReader.java
@@ -1,0 +1,13 @@
+package com.nanosai.rionops.rion.read.object;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public interface IRionFieldReader {
+
+    public int read(byte[] source, int sourceOffset, Object destination);
+
+    public void setNull(Object destination);
+
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/IRionObjectReaderConfigurator.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/IRionObjectReaderConfigurator.java
@@ -1,0 +1,13 @@
+package com.nanosai.rionops.rion.read.object;
+
+/**
+ * An IRionObjectReaderConfigurator can configure the individual field readers of an RionObjectReader. An implementation
+ * of this interface is passed to the constructor of the RionObjectReader. The RionObjectReader then calls the implementation
+ * of this interface to obtain configuration for each field in the class the RionObjectReader is targeted at.
+ *
+ */
+public interface IRionObjectReaderConfigurator {
+
+    public void configure(RionFieldReaderConfiguration config);
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayByte.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayByte.java
@@ -1,0 +1,56 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderArrayByte implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderArrayByte(Field field) {
+        this.field = field;
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int lengthLength = leadByte & 15;
+
+        if(lengthLength == 0){
+            return 1; //string field (UTF-8) with null value is always 1 byte long
+        }
+
+        //int fieldType    = leadByte >> 4;   //todo use field type for validation?
+
+        int length = 255 & source[sourceOffset++];
+        for(int i=1; i<lengthLength; i++){
+            length <<= 8;
+            length |= 255 & source[sourceOffset++];
+        }
+
+        byte[] value = new byte[length];
+        System.arraycopy(source, sourceOffset, value, 0, length);
+
+        try {
+            field.set(destination, value);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + lengthLength + length;
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayDouble.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayDouble.java
@@ -1,0 +1,81 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderArrayDouble implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderArrayDouble(Field field) {
+        this.field = field;
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int lengthLength = leadByte & 15;
+
+        if(lengthLength == 0){
+            return 1; //string field (UTF-8) with null value is always 1 byte long
+        }
+
+        //int fieldType    = leadByte >> 4;   //todo use field type for validation?
+
+        //read array field length (in bytes)
+        int length = 255 & source[sourceOffset++];
+        for(int i=1; i<lengthLength; i++){
+            length <<= 8;
+            length |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array field element count
+        int elementCountLeadByte = source[sourceOffset++];
+        int elementCountLength   = elementCountLeadByte & 15;
+
+        int elementCount = 0;
+        for(int i=0; i<elementCountLength; i++){
+            elementCount <<= 8;
+            elementCount |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array elements
+        double[] values = new double[elementCount];
+
+        for(int i=0; i<elementCount; i++){
+            int elementLeadByte = 255 & source[sourceOffset++];
+            int elementLength   = elementLeadByte & 15;
+            long elementValue   = 0;
+            for(int j=0; j<elementLength; j++){
+                elementValue <<= 8;
+                elementValue |= 255 & source[sourceOffset++];
+            }
+            values[i] = Double.longBitsToDouble(elementValue);
+        }
+
+
+        try {
+            field.set(destination, values);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + lengthLength + length;
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayFloat.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayFloat.java
@@ -1,0 +1,81 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderArrayFloat implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderArrayFloat(Field field) {
+        this.field = field;
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int lengthLength = leadByte & 15;
+
+        if(lengthLength == 0){
+            return 1; //string field (UTF-8) with null value is always 1 byte long
+        }
+
+        //int fieldType    = leadByte >> 4;   //todo use field type for validation?
+
+        //read array field length (in bytes)
+        int length = 255 & source[sourceOffset++];
+        for(int i=1; i<lengthLength; i++){
+            length <<= 8;
+            length |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array field element count
+        int elementCountLeadByte = source[sourceOffset++];
+        int elementCountLength   = elementCountLeadByte & 15;
+
+        int elementCount = 0;
+        for(int i=0; i<elementCountLength; i++){
+            elementCount <<= 8;
+            elementCount |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array elements
+        float[] values = new float[elementCount];
+
+        for(int i=0; i<elementCount; i++){
+            int elementLeadByte = 255 & source[sourceOffset++];
+            int elementLength   = elementLeadByte & 15;
+            int elementValue   = 0;
+            for(int j=0; j<elementLength; j++){
+                elementValue <<= 8;
+                elementValue |= 255 & source[sourceOffset++];
+            }
+            values[i] = Float.intBitsToFloat(elementValue);
+        }
+
+
+        try {
+            field.set(destination, values);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + lengthLength + length;
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayInt.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayInt.java
@@ -1,0 +1,87 @@
+package com.nanosai.rionops.rion.read.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderArrayInt implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderArrayInt(Field field) {
+        this.field = field;
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int lengthLength = leadByte & 15;
+
+        if(lengthLength == 0){
+            return 1; //string field (UTF-8) with null value is always 1 byte long
+        }
+
+        //int fieldType    = leadByte >> 4;   //todo use field type for validation?
+
+        //read array field length (in bytes)
+        int length = 255 & source[sourceOffset++];
+        for(int i=1; i<lengthLength; i++){
+            length <<= 8;
+            length |= 255 & source[sourceOffset++];
+        }
+
+        //read array field element count
+        int elementCountLeadByte = source[sourceOffset++];
+        int elementCountLength   = elementCountLeadByte & 15;
+
+        int elementCount = 0;
+        for(int i=0; i<elementCountLength; i++){
+            elementCount <<= 8;
+            elementCount |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array elements
+        int[] values = new int[elementCount];
+
+        for(int i=0; i<elementCount; i++){
+            int elementLeadByte = 255 & source[sourceOffset++];
+            int elementLength   = elementLeadByte & 15;
+            int elementValue   = 0;
+            for(int j=0; j<elementLength; j++){
+                elementValue <<= 8;
+                elementValue |= 255 & source[sourceOffset++];
+            }
+            if( (elementLeadByte >> 4) == RionFieldTypes.INT_POS){
+                values[i] = elementValue;
+            } else {
+                values[i] = (-elementValue)-1;
+            }
+        }
+
+
+        try {
+            field.set(destination, values);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + lengthLength + length;
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayLong.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayLong.java
@@ -1,0 +1,88 @@
+package com.nanosai.rionops.rion.read.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderArrayLong implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderArrayLong(Field field) {
+        this.field = field;
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int lengthLength = leadByte & 15;
+
+        if(lengthLength == 0){
+            return 1; //string field (UTF-8) with null value is always 1 byte long
+        }
+
+        //int fieldType    = leadByte >> 4;   //todo use field type for validation?
+
+        //read array field length (in bytes)
+        int length = 255 & source[sourceOffset++];
+        for(int i=1; i<lengthLength; i++){
+            length <<= 8;
+            length |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array field element count
+        int elementCountLeadByte = source[sourceOffset++];
+        int elementCountLength   = elementCountLeadByte & 15;
+
+        int elementCount = 0;
+        for(int i=0; i<elementCountLength; i++){
+            elementCount <<= 8;
+            elementCount |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array elements
+        long[] values = new long[elementCount];
+
+        for(int i=0; i<elementCount; i++){
+            int elementLeadByte = 255 & source[sourceOffset++];
+            int elementLength   = elementLeadByte & 15;
+            long elementValue   = 0;
+            for(int j=0; j<elementLength; j++){
+                elementValue <<= 8;
+                elementValue |= 255 & source[sourceOffset++];
+            }
+            if( (elementLeadByte >> 4) == RionFieldTypes.INT_POS){
+                values[i] = elementValue;
+            } else {
+                values[i] = (-elementValue)-1;
+            }
+        }
+
+
+        try {
+            field.set(destination, values);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + lengthLength + length;
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayShort.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderArrayShort.java
@@ -1,0 +1,88 @@
+package com.nanosai.rionops.rion.read.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderArrayShort implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderArrayShort(Field field) {
+        this.field = field;
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int lengthLength = leadByte & 15;
+
+        if(lengthLength == 0){
+            return 1; //string field (UTF-8) with null value is always 1 byte long
+        }
+
+        //int fieldType    = leadByte >> 4;   //todo use field type for validation?
+
+        //read array field length (in bytes)
+        int length = 255 & source[sourceOffset++];
+        for(int i=1; i<lengthLength; i++){
+            length <<= 8;
+            length |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array field element count
+        int elementCountLeadByte = source[sourceOffset++];
+        int elementCountLength   = elementCountLeadByte & 15;
+
+
+        int elementCount = 0;
+        for(int i=0; i<elementCountLength; i++){
+            elementCount <<= 8;
+            elementCount |= 255 & source[sourceOffset++];
+        }
+
+
+        //read array elements
+        short[] values = new short[elementCount];
+
+        for(int i=0; i<elementCount; i++){
+            int elementLeadByte = 255 & source[sourceOffset++];
+            int elementLength   = elementLeadByte & 15;
+            int elementValue   = 0;
+            for(int j=0; j<elementLength; j++){
+                elementValue <<= 8;
+                elementValue |= 255 & source[sourceOffset++];
+            }
+            if( (elementLeadByte >> 4) == RionFieldTypes.INT_POS){
+                values[i] = (short) elementValue;
+            } else {
+                values[i] = (short) ((-elementValue)-1);
+            }
+        }
+
+
+        try {
+            field.set(destination, values);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + lengthLength + length;
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderBoolean.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderBoolean.java
@@ -1,0 +1,51 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderBoolean implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderBoolean(Field field) {
+        this.field = field;
+    }
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int value = (255 & source[sourceOffset]);
+        value &=15;
+
+        switch(value){
+            case 1 : {
+                try {
+                    field.set(destination, true);
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+                break;
+            }
+            case 2 : {
+                try {
+                    field.set(destination, false);
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+                break;
+            }
+            default : {
+                //do nothing - boolean value is either null (0) or undefined (3,4,5,6 or 7).
+            }
+        }
+
+        return 1; // boolean field is always 1 byte long
+    }
+
+    @Override
+    public void setNull(Object destination) {
+
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderByte.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderByte.java
@@ -1,0 +1,56 @@
+package com.nanosai.rionops.rion.read.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderByte implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderByte(Field field) {
+        this.field = field;
+    }
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        //int fieldType    = leadByte >> 3;  //todo use field type for validation ?
+        int length = leadByte & 15;
+
+        if(length == 0){
+            return 1; //byte field with null value is always 1 byte long.
+        }
+
+        byte theByte = (byte) (255 & source[sourceOffset++]);
+        for(int i=1;i<length; i++){
+            theByte <<= 8;
+            theByte |= 255 & source[sourceOffset++];
+        }
+        if( (leadByte >> 4) == RionFieldTypes.INT_NEG){
+            theByte = (byte) ((-theByte) - 1);
+        }
+
+
+        try {
+            field.set(destination, theByte);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + length;
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderCalendar.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderCalendar.java
@@ -1,0 +1,91 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.lang.reflect.Field;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderCalendar implements IRionFieldReader {
+
+    private static TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+
+
+    private Field field = null;
+
+    public RionFieldReaderCalendar(Field field) {
+        this.field = field;
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int lengthLength = leadByte & 15;
+
+        if(lengthLength == 0){
+            return 1; //string field (UTF-8) with null value is always 1 byte long
+        }
+
+        //int fieldType    = leadByte >> 4;   //todo use field type for validation?
+
+        //todo can be optimized ?
+        GregorianCalendar calendar = new GregorianCalendar();
+        calendar.setTimeZone(UTC_TIME_ZONE);
+        calendar.set(Calendar.MONTH, 0);
+        calendar.set(Calendar.DAY_OF_MONTH, 1);
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        try {
+            field.set(destination, calendar);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        int year = (255) & source[sourceOffset++];
+        year <<=8;
+        year |= (255) & source[sourceOffset++];
+        calendar.set(Calendar.YEAR, year);
+        if(lengthLength == 2){ return 3; /* 1 + length (2) */ }
+
+        calendar.set(Calendar.MONTH, (255 & source[sourceOffset++]) -1);
+        if(lengthLength == 3){ return 4; /* 1 + length (3) */ }
+
+        calendar.set(Calendar.DAY_OF_MONTH, (255 & source[sourceOffset++]));
+        if(lengthLength == 4){ return 5; /* 1 + length (4) */ }
+
+        calendar.set(Calendar.HOUR_OF_DAY, (255 & source[sourceOffset++]));
+        if(lengthLength == 5){ return 6; /* 1 + length (5) */ }
+
+        calendar.set(Calendar.MINUTE, (255 & source[sourceOffset++]));
+        if(lengthLength == 6){ return 7; /* 1 + length (6) */ }
+
+        calendar.set(Calendar.SECOND, (255 & source[sourceOffset++]));
+        if(lengthLength == 7){ return 8; /* 1 + length (7) */ }
+
+        int millis = 255 & source[sourceOffset++];
+        millis <<= 8;
+        millis |= 255 & source[sourceOffset++];
+        calendar.set(Calendar.MILLISECOND, millis);
+
+        if(lengthLength == 9){ return 10; /* 1 + length (9) */ }
+
+        return 1 + lengthLength;
+    }
+
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderConfiguration.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderConfiguration.java
@@ -1,0 +1,29 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.lang.reflect.Field;
+
+/**
+ * A configuration for a single IRionFieldReader (used internally by the RionObjectReader).
+ *
+ * An IRionObjectReaderConfigurator can read the <code>field</code> field to see what field (field reader)
+ * this configuration is for.
+ *
+ * The fieldName of the field is stored in the <code>fieldName</code> field (but is also accessible
+ * via field.getName()).
+ *
+ * The <code>include</code> field defaults to true, but can be set to false. The RionObjectReader will then not
+ * include read values for this field from the ION data, even if that field is present.
+ *
+ * The <code>alias</code> field can be used if the field has a different fieldName in the ION data than the
+ * field has in the Java object.
+ */
+public class RionFieldReaderConfiguration {
+    public Field   field   = null;
+    public String fieldName = null;
+
+
+    public boolean include = true;
+    public String  alias   = null;
+
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderDouble.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderDouble.java
@@ -1,0 +1,70 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderDouble implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderDouble(Field field) {
+        this.field = field;
+    }
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        //int fieldType    = leadByte >> 3;  //todo use for field match verification?
+
+        int length = leadByte & 15;  // 15 = binary 00001111 - filters out 4 top bits
+
+        if(length == 0){
+            return 1; //double field with null value is only 1 byte long
+        }
+
+        /*
+        long theLong = 255 & source[sourceOffset++];;
+        for(int i=1;i<length; i++){
+            theLong <<= 8;
+            theLong |= 255 & source[sourceOffset++];
+        }
+        */
+
+        long theLong = 255 & source[sourceOffset++];
+        theLong <<= 8;
+        theLong |= 255 & source[sourceOffset++];
+        theLong <<= 8;
+        theLong |= 255 & source[sourceOffset++];
+        theLong <<= 8;
+        theLong |= 255 & source[sourceOffset++];
+        theLong <<= 8;
+        theLong |= 255 & source[sourceOffset++];
+        theLong <<= 8;
+        theLong |= 255 & source[sourceOffset++];
+        theLong <<= 8;
+        theLong |= 255 & source[sourceOffset++];
+        theLong <<= 8;
+        theLong |= 255 & source[sourceOffset++];
+
+
+        try {
+            field.set(destination, Double.longBitsToDouble(theLong));
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + length;
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderFloat.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderFloat.java
@@ -1,0 +1,60 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderFloat implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderFloat(Field field) {
+        this.field = field;
+    }
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        //int fieldType    = leadByte >> 3;  //use for validation of field type?
+        int length = leadByte & 15;
+
+        if(length == 0){
+            return 1;  // float field with null value is always 1 byte long
+        }
+
+        /*
+        int theInt = 255 & source[sourceOffset++];
+        for(int i=1; i < length; i++){
+            theInt <<= 8;
+            theInt |= 255 & source[sourceOffset++];
+        }
+        */
+        int theInt = 255 & source[sourceOffset++];
+        theInt <<= 8;
+        theInt |= 255 & source[sourceOffset++];
+        theInt <<= 8;
+        theInt |= 255 & source[sourceOffset++];
+        theInt <<= 8;
+        theInt |= 255 & source[sourceOffset++];
+
+        try {
+            field.set(destination, Float.intBitsToFloat(theInt));
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + length;
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderInt.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderInt.java
@@ -1,0 +1,58 @@
+package com.nanosai.rionops.rion.read.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderInt implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderInt(Field field) {
+        this.field = field;
+    }
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        //int fieldType    = leadByte >> 3;    // todo use for field type validation?
+
+        int length       = leadByte & 15;
+
+        if(length == 0){
+            return 1; //int field with null value is always 1 byte long
+        }
+
+        int theInt = 255 & source[sourceOffset++];
+        for(int i=1;i<length; i++){
+            theInt <<= 8;
+            theInt |= 255 & source[sourceOffset++];
+        }
+        if( (leadByte >> 4) == RionFieldTypes.INT_NEG){
+            theInt = (-theInt) - 1;
+        }
+
+        try {
+            field.set(destination, theInt);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + length;
+
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderLong.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderLong.java
@@ -1,0 +1,56 @@
+package com.nanosai.rionops.rion.read.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderLong implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderLong(Field field) {
+        this.field = field;
+    }
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = source[sourceOffset++];
+        //int fieldType    = leadByte >> 3;  //todo use field type for validation ?
+        int length = leadByte & 15;
+
+        if(length == 0){
+            return 1; //long field with null value is always 1 byte long
+        }
+
+        long theLong = 0;
+        for(int i=0;i<length; i++){
+            theLong <<= 8;
+            theLong |= (255 & source[sourceOffset++]);
+        }
+        if( (leadByte >> 4) == RionFieldTypes.INT_NEG){
+            theLong = (-theLong) - 1;
+        }
+
+
+        try {
+            field.set(destination, theLong);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + length;
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderNop.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderNop.java
@@ -1,0 +1,66 @@
+package com.nanosai.rionops.rion.read.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderNop implements IRionFieldReader {
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int fieldType    = leadByte >> 4;
+        int lengthLength = leadByte & 15;  // 7 = binary 00000111 - filters out 5 top bits
+
+        if(lengthLength == 0){
+            return 1; //field with null value is always 1 byte long
+        }
+
+        //todo skip correct amount of bytes - depending on field type. Not all field types have explicit length bytes.
+
+        switch(fieldType){
+            case RionFieldTypes.BOOLEAN: {
+                return 1;
+            }
+            case RionFieldTypes.UTF_8_SHORT: ;
+            case RionFieldTypes.UTC_DATE_TIME: ;
+            //case RionFieldTypes.COMPLEX_TYPE_ID_SHORT: ;
+            case RionFieldTypes.KEY_SHORT: ;
+            case RionFieldTypes.INT_POS: ;
+            case RionFieldTypes.INT_NEG: ;
+            case RionFieldTypes.FLOAT : {
+                return 1 + lengthLength;
+            }
+
+            case RionFieldTypes.EXTENDED : {
+                int fieldTypeExtended = source[sourceOffset++]; //read extended field type - first byte after lead byte
+                switch(fieldTypeExtended) {
+                    case RionFieldTypes.ELEMENT_COUNT : {
+                        return 1 + 1 + lengthLength; //element count uses extended short encoding.
+                    }
+                }
+                return 1 + 1 + lengthLength; //default extended element encoding uses 1 byte for extended type
+            }
+
+            //fine for all fields that use the lengthLength field normally - meaning Normal length fields (not Short and Tiny).
+            default : {
+                int fieldLength = 0;
+                for(int i=0; i<lengthLength; i++){
+                    fieldLength <<= 8;
+                    fieldLength |= 255 & source[sourceOffset++];
+                }
+                return 1 + lengthLength + fieldLength;
+            }
+        }
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        //do nothing, right?
+    }
+
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderObject.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderObject.java
@@ -1,0 +1,139 @@
+package com.nanosai.rionops.rion.read.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderObject implements IRionFieldReader {
+
+    private Field field     = null;
+    private Class typeClass = null;
+
+    private Field[] fields = null;
+
+    private Map<RionKeyFieldKey, IRionFieldReader> fieldReaderMap = new HashMap<>();
+    private RionFieldReaderNop nopFieldReader = new RionFieldReaderNop();
+
+    private RionKeyFieldKey currentKeyFieldKey = new RionKeyFieldKey();
+
+    public RionFieldReaderObject(Field field, IRionObjectReaderConfigurator configurator) {
+        this.field     = field;
+        this.typeClass = field.getType();
+        this.fields    = this.typeClass.getDeclaredFields();
+    }
+
+    public void generateFieldReaders(IRionObjectReaderConfigurator configurator, Map<Field, IRionFieldReader> existingFieldReaders) {
+        this.fieldReaderMap = RionFieldReaderUtil.createFieldReaders(this.fields, configurator, existingFieldReaders);
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object finalDestination) {
+        this.currentKeyFieldKey.setSource(source);
+
+        Object destination =  instantiateType();
+
+        int leadByte = 255 & source[sourceOffset++];
+        int fieldType = leadByte >> 4;
+
+        //todo if not object - throw exception
+
+        int lengthLength = leadByte & 15;  // 15 = binary 00001111 - filters out 4 top bits
+
+        if(lengthLength == 0){
+            return 1; //object field with value null is always 1 byte long.
+        }
+
+        int length = 255 & source[sourceOffset++];
+        for(int i=1; i<lengthLength; i++){
+            length <<= 8;
+            length |= 255 & source[sourceOffset++];
+        }
+        int endIndex = sourceOffset + length;
+
+        while(sourceOffset < endIndex){
+            leadByte     = 255 & source[sourceOffset++];
+            fieldType    = leadByte >> 4;
+            lengthLength = leadByte & 15;  // 15 = binary 00001111 - filters out 4 top bits
+
+            //todo can this be optimized with a switch statement?
+
+            //expect a key field
+            if(fieldType == RionFieldTypes.KEY || fieldType == RionFieldTypes.KEY_SHORT){
+
+                //distinguish between length and lengthLength depending on compact key field or normal key field
+                length = 0;
+                if(fieldType == RionFieldTypes.KEY_SHORT){
+                    length = leadByte & 15;
+                } else {
+                    for(int i=0; i<lengthLength; i++){
+                        length <<= 8;
+                        length |= 255 & source[sourceOffset++];
+                    }
+                }
+
+                this.currentKeyFieldKey.setOffsets(sourceOffset, length);
+
+                IRionFieldReader reader = this.fieldReaderMap.get(this.currentKeyFieldKey);
+                if(reader == null){
+                    reader = this.nopFieldReader;
+                }
+
+                //find beginning of next field value - then call field reader.
+                sourceOffset += length;
+
+                //todo check for end of object - if found, call reader.setNull() - no value field following the key field.
+
+                int nextLeadByte  = 255 & source[sourceOffset];
+                int nextFieldType = nextLeadByte >> 4;
+
+                if(nextFieldType != RionFieldTypes.KEY && nextFieldType != RionFieldTypes.KEY_SHORT){
+                    sourceOffset += reader.read(source, sourceOffset, destination);
+                } else {
+                    //next field is also a key - meaning the previous key has a value of null (no value field following it).
+                    reader.setNull(destination);
+                }
+            }
+
+        }
+
+        try {
+            this.field.set(finalDestination, destination);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + lengthLength + length;
+
+    }
+
+
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Object instantiateType() {
+        try {
+            return this.typeClass.newInstance();
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return null; //todo remove later when rethrowing exceptions.
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderShort.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderShort.java
@@ -1,0 +1,56 @@
+package com.nanosai.rionops.rion.read.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderShort implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderShort(Field field) {
+        this.field = field;
+    }
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        //int fieldType    = leadByte >> 3;  //todo use field type for validation ?
+        int length = leadByte & 15;
+
+        if(length == 0){
+            return 1; //short field with null value is always 1 byte long.
+        }
+
+        short theShort = (short) (255 & source[sourceOffset++]);
+        for(int i=1;i<length; i++){
+            theShort <<= 8;
+            theShort |= 255 & source[sourceOffset++];
+        }
+        if( (leadByte >> 4) == RionFieldTypes.INT_NEG){
+            theShort = (short) ((-theShort) - 1);
+        }
+
+
+        try {
+            field.set(destination, theShort);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1 + length;
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderString.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderString.java
@@ -1,0 +1,72 @@
+package com.nanosai.rionops.rion.read.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionFieldReaderString implements IRionFieldReader {
+
+    private Field field = null;
+
+    public RionFieldReaderString(Field field) {
+        this.field = field;
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int leadByte     = 255 & source[sourceOffset++];
+        int lengthLength = leadByte & 15;
+
+        if(lengthLength == 0){
+            return 1; //string field (UTF-8) with null value is always 1 byte long
+        }
+
+        int fieldType    = leadByte >> 4;   //todo use field type for validation?
+        if(fieldType == RionFieldTypes.UTF_8_SHORT){
+            int length = lengthLength;
+
+            try {
+                field.set(destination, new String(source, sourceOffset, length, "UTF-8"));
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+
+            return 1 + length;
+
+        } else {
+            int length = 255 & source[sourceOffset++];
+            for(int i=1; i<lengthLength; i++){
+                length <<= 8;
+                length |= 255 & source[sourceOffset++];
+            }
+
+            try {
+                field.set(destination, new String(source, sourceOffset, length, "UTF-8"));
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+
+            return 1 + lengthLength + length;
+        }
+
+    }
+
+    @Override
+    public void setNull(Object destination) {
+        try {
+            field.set(destination, null);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderTable.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderTable.java
@@ -1,0 +1,173 @@
+package com.nanosai.rionops.rion.read.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by jjenkov on 11-11-2015.
+ */
+public class RionFieldReaderTable implements IRionFieldReader {
+
+    private Field field       = null;
+    private Class typeInTable = null;
+    private Field[] typeInTableFields = null;
+    private Map<RionKeyFieldKey, IRionFieldReader> fieldReaderMap = null;
+    private RionFieldReaderNop nopFieldReader = new RionFieldReaderNop();
+
+    private List tempList = new ArrayList();
+
+
+    //This array is first used when reading field values from a table. First the key fields are used to obtain
+    //IIapFieldReader instances from the fieldReaderMap. The IIapFieldReader instances are inserted into this
+    //array according to the order their corresponding key fields appear in the beginning of the table.
+    //Afterwards the value fields in the table are read using the IIapFieldReader instances in this array,
+    //cycling through the fieldReaderArray until there are no more value fields in the table.
+    private IRionFieldReader[] fieldReaderArray = null;
+
+    private RionKeyFieldKey tempKeyFieldKey = new RionKeyFieldKey();
+
+    public RionFieldReaderTable(Field field, IRionObjectReaderConfigurator configurator) {
+        this.field             = field;
+        this.typeInTable       = field.getType().getComponentType();  // field type is an array, so we need to get to the component type of the array.
+        this.typeInTableFields = typeInTable.getDeclaredFields();
+        this.fieldReaderArray  = new IRionFieldReader[typeInTableFields.length];
+    }
+
+    public void generateFieldReaders(IRionObjectReaderConfigurator configurator, Map<Field, IRionFieldReader> existingFieldReaders) {
+        this.fieldReaderMap = RionFieldReaderUtil.createFieldReaders(this.typeInTableFields, configurator, existingFieldReaders);
+    }
+
+
+    @Override
+    public int read(byte[] source, int sourceOffset, Object destination) {
+        int tableStartIndex = sourceOffset;
+
+        int tableLeadByte = 255 & source[sourceOffset++];
+        int tableLengthLength  = tableLeadByte & 15;
+
+        if(tableLengthLength == 0){
+            return 1; //table field with null as values is always 1 byte long (has 0 keys and 0 values).
+        }
+
+        int tableLength = 255 & source[sourceOffset++];
+        for(int i=1; i < tableLengthLength; i++){
+            tableLength <<= 8;
+            tableLength |= 255 & source[sourceOffset++];
+        }
+
+        int tableEndIndex = tableStartIndex + 1 + tableLengthLength + tableLength;
+
+        //read table field element count (row count)
+        int elementCountLeadByte = source[sourceOffset++];
+        int elementCountLength   = elementCountLeadByte & 15;
+
+        int elementCount = 0;
+        for(int i=0; i<elementCountLength; i++){
+            elementCount <<= 8;
+            elementCount |= 255 & source[sourceOffset++];
+        }
+
+
+        //read the key fields of the table
+        tempKeyFieldKey.setSource(source);
+        int fieldReadersInArray = 0;
+
+        IRionFieldReader tempFieldReader = null;
+        boolean endOfKeyFieldsFound = false;
+        while(!endOfKeyFieldsFound){
+            int fieldLeadByte = 255 & source[sourceOffset++];
+            int fieldType     = fieldLeadByte >> 4;
+
+            switch(fieldType){
+                case RionFieldTypes.KEY_SHORT:  {
+                    int keyLength = fieldLeadByte & 15;
+                    tempKeyFieldKey.setOffsets(sourceOffset, keyLength);
+                    tempFieldReader = this.fieldReaderMap.get(tempKeyFieldKey);
+                    if(tempFieldReader == null){
+                        tempFieldReader = this.nopFieldReader;
+                    }
+                    this.fieldReaderArray[fieldReadersInArray++] = tempFieldReader;
+                    sourceOffset += keyLength;
+                    break;
+                }
+                case RionFieldTypes.KEY : {
+                    int keyLengthLength = fieldLeadByte & 15;
+                    int keyLength = 0;
+                    for(int i=0; i < tableLengthLength; i++){
+                        keyLength <<= 8;
+                        keyLength |= 255 & source[sourceOffset++];
+                    }
+                    tempKeyFieldKey.setOffsets(sourceOffset, keyLength);
+                    tempFieldReader = this.fieldReaderMap.get(tempKeyFieldKey);
+                    if(tempFieldReader == null){
+                        tempFieldReader = this.nopFieldReader;
+                    }
+                    this.fieldReaderArray[fieldReadersInArray++] = tempFieldReader;
+                    sourceOffset += keyLength;
+                    break;
+                }
+
+                default : {
+                    endOfKeyFieldsFound = true;
+                }
+            }
+        }
+
+        //start reading the value fields.
+        sourceOffset--; //will have skipped over the lead byte of first value field during search for key fields.
+
+        Object arrayInstance = Array.newInstance(this.typeInTable, elementCount);
+        int fieldReaderIndex = 0;
+        Object objectInTable = null;
+        int arrayIndex = 0;
+        while(sourceOffset < tableEndIndex){
+            if(fieldReaderIndex == 0) {
+                try {
+                    objectInTable = this.typeInTable.newInstance();
+                    Array.set(arrayInstance, arrayIndex++, objectInTable);
+                    //this.tempList.add(objectInTable);
+                } catch (InstantiationException e) {
+                    e.printStackTrace();
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            sourceOffset += this.fieldReaderArray[fieldReaderIndex++]
+                                .read(source, sourceOffset, objectInTable);
+
+            if(fieldReaderIndex == fieldReadersInArray){
+                fieldReaderIndex = 0; // cycle back to first field reader.
+            }
+        }
+
+        //Object arrayInstance = Array.newInstance(this.typeInTable, this.tempList.size());
+        /*
+        for(int i=0, n=this.tempList.size(); i < n; i++){
+            Array.set(arrayInstance, i, this.tempList.get(i));   //todo perhaps use a faster data type than ArrayList
+        }
+        */
+
+        try {
+            this.field.set(destination, arrayInstance);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        this.tempList.clear();
+
+        return tableEndIndex - tableStartIndex; //is this correct? I think so.
+    }
+
+
+    @Override
+    public void setNull(Object destination) {
+
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderUtil.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionFieldReaderUtil.java
@@ -1,0 +1,128 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RionFieldReaderUtil {
+
+
+    public static Map<RionKeyFieldKey, IRionFieldReader> createFieldReaders(
+            Field[] fields,
+            IRionObjectReaderConfigurator configurator,
+            Map<Field, IRionFieldReader> existingFieldReaders) {
+
+        RionFieldReaderConfiguration          fieldConfiguration = new RionFieldReaderConfiguration();
+        Map<RionKeyFieldKey, IRionFieldReader> fieldReaderMap     = new HashMap<>();
+
+        for(int i=0; i < fields.length; i++){
+
+            fieldConfiguration.field     = fields[i];
+            fieldConfiguration.fieldName = fields[i].getName();
+            fieldConfiguration.alias     = fields[i].getName();
+            fieldConfiguration.include   = true;
+
+            configurator.configure(fieldConfiguration);
+
+            if(existingFieldReaders.containsKey(fields[i])){
+                IRionFieldReader fieldReader = existingFieldReaders.get(fields[i]);
+                try {
+                    fieldReaderMap.put(new RionKeyFieldKey(fieldConfiguration.alias.getBytes("UTF-8")), fieldReader); //todo this is wrong - should be IonKeyFieldKey - except those are not unique to classes...
+                } catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                    //todo better exception handling, although UTF-8 is a known encoding.
+                }
+                continue;
+            }
+
+
+            if (fieldConfiguration.include) {
+                IRionFieldReader fieldReader = RionFieldReaderUtil.createFieldReader(fields[i], configurator);
+
+                existingFieldReaders.put(fields[i], fieldReader);
+
+                if(fieldReader instanceof RionFieldReaderObject){
+                    ((RionFieldReaderObject) fieldReader).generateFieldReaders(configurator, existingFieldReaders);
+                } else if(fieldReader instanceof RionFieldReaderTable){
+                    ((RionFieldReaderTable) fieldReader).generateFieldReaders(configurator, existingFieldReaders);
+                }
+
+                try {
+                    fieldReaderMap.put(new RionKeyFieldKey(fieldConfiguration.alias.getBytes("UTF-8")), fieldReader);
+                } catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                    //todo throw exception - but will never happen since UTF-8 is a known encoding.
+                }
+            }
+        }
+        return fieldReaderMap;
+    }
+
+
+    public static IRionFieldReader createFieldReader(Field field, IRionObjectReaderConfigurator configurator){
+
+        field.setAccessible(true); //allows access to private fields, and supposedly speeds up reflection...  ?
+        Class fieldType = field.getType();
+
+        if(boolean.class.equals(fieldType)){
+            return new RionFieldReaderBoolean(field);
+        }
+        if(byte.class.equals(fieldType)){
+            return new RionFieldReaderByte(field);
+        }
+        if(short.class.equals(fieldType)){
+            return new RionFieldReaderShort(field);
+        }
+        if(int.class.equals(fieldType)){
+            return new RionFieldReaderInt(field);
+        }
+        if(long.class.equals(fieldType)){
+            return new RionFieldReaderLong(field);
+        }
+        if(float.class.equals(fieldType)){
+            return new RionFieldReaderFloat(field);
+        }
+        if(double.class.equals(fieldType)){
+            return new RionFieldReaderDouble(field);
+        }
+        if(String.class.equals(fieldType)){
+            return new RionFieldReaderString(field);
+        }
+        if(Calendar.class.equals(fieldType)){
+            return new RionFieldReaderCalendar(field);
+        }
+        if(GregorianCalendar.class.equals(fieldType)){
+            return new RionFieldReaderCalendar(field);
+        }
+        if(fieldType.isArray()){
+            if(byte.class.equals(fieldType.getComponentType())){
+                return new RionFieldReaderArrayByte(field);
+            }
+            if(short.class.equals(fieldType.getComponentType())){
+                return new RionFieldReaderArrayShort(field);
+            }
+            if(int.class.equals(fieldType.getComponentType())){
+                return new RionFieldReaderArrayInt(field);
+            }
+            if(long.class.equals(fieldType.getComponentType())){
+                return new RionFieldReaderArrayLong(field);
+            }
+            if(float.class.equals(fieldType.getComponentType())){
+                return new RionFieldReaderArrayFloat(field);
+            }
+            if(double.class.equals(fieldType.getComponentType())){
+                return new RionFieldReaderArrayDouble(field);
+            }
+            return new RionFieldReaderTable(field, configurator);
+        } else {
+            return new RionFieldReaderObject(field, configurator);
+        }
+
+        //todo support object field writer
+
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionKeyFieldKey.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionKeyFieldKey.java
@@ -1,0 +1,85 @@
+package com.nanosai.rionops.rion.read.object;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * A key for a key field. The KeyFieldKey is used as key to find a
+ *
+ * Created by jjenkov on 05-11-2015.
+ */
+public class RionKeyFieldKey {
+    byte[] source = null;
+    int startOffset = 0;  //the start offset of the *value* of the key field (after lead byte + length bytes) - not the start offset of the key field itself (lead byte).
+    int    length   = 0;
+
+    int    hashCode = -1;
+
+    public RionKeyFieldKey() {
+    }
+
+    public RionKeyFieldKey(byte[] source){
+        this(source, 0, source.length);
+    }
+
+    public RionKeyFieldKey(byte[] source, int startOffset, int length) {
+        this.source = source;
+
+        setOffsets(startOffset, length);
+    }
+
+    public void setSource(byte[] source){
+        this.source = source;
+    }
+
+    public void setOffsets(int startOffset, int length){
+        this.startOffset = startOffset;
+        this.length = length;
+
+        this.calcHashCode();
+    }
+
+
+    @Override
+    public int hashCode() {
+        return this.hashCode;
+    }
+
+
+    int calcHashCode() {
+        this.hashCode = 0;
+        for(int i= startOffset, n= startOffset + length; i<n; i++){
+            this.hashCode += source[i];
+        }
+        return this.hashCode;
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        RionKeyFieldKey otherKey = (RionKeyFieldKey) obj;
+
+        if(this.hashCode != otherKey.hashCode){ return false; }
+        if(this.length   != otherKey.length)  { return false; }
+
+        for(int i=0; i<length; i++){
+            if(this.source[this.startOffset + i] != otherKey.source[otherKey.startOffset + i]){
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public int length() {
+        return this.length;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return new String(source, startOffset, length, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace(); //won't happen - UTF-8 always supported.
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionObjectReader.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionObjectReader.java
@@ -1,0 +1,154 @@
+package com.nanosai.rionops.rion.read.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An RionObjectReader instance can read an object (instance) of some class from ION data ("normalize" the object in
+ * other words). An RionObjectReader instance is targeted at a single Java class. To read objects of multiple classes,
+ * create on RionObjectReader per class you want to read instances of.
+ *
+ *
+ */
+public class RionObjectReader<T> {
+
+    private Class typeClass = null;
+
+    private Map<RionKeyFieldKey, IRionFieldReader> fieldReaderMap = new HashMap<>();
+    private RionFieldReaderNop nopFieldReader = new RionFieldReaderNop();
+
+    private RionKeyFieldKey currentKeyFieldKey = new RionKeyFieldKey();
+
+
+    /**
+     * Creates an RionObjectReader targeted at the given class.
+     * @param typeClass The class this RionObjectReader instance should be able to read instances of, from ION data.
+     */
+    public RionObjectReader(Class<T> typeClass) {
+        this(typeClass, new RionObjectReaderConfiguratorNopImpl());
+     }
+
+
+    /**
+     * Creates an RionObjectReader targeted at the given class.
+     * The IRionObjectReaderConfigurator can configure (modify) this RionObjectReader instance.
+     * For instance, the configurator can signal that some fields should not be read, or that different field names
+     * are used in the ION data which should be mapped to other field names in the target Java class.
+     *
+     * @param typeClass The class this RionObjectReader instance should be able to read instances of, from ION data.
+     * @param configurator  The configurator that can configure each field reader (one per field in the target class) of this RionObjectReader - even exclude them.
+     */
+    public RionObjectReader(Class<T> typeClass, IRionObjectReaderConfigurator configurator) {
+        this.typeClass = typeClass;
+        Field[] fields = this.typeClass.getDeclaredFields();
+
+        this.fieldReaderMap = RionFieldReaderUtil.createFieldReaders(fields, configurator, new HashMap<>());
+    }
+
+
+
+    private void putFieldReader(String fieldName, IRionFieldReader fieldReader) {
+        try {
+            this.fieldReaderMap.put(new RionKeyFieldKey(fieldName.getBytes("UTF-8")), fieldReader);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    public Object read(byte[] source, int sourceOffset){
+        return read(source, sourceOffset, instantiateType());
+    }
+
+
+    public Object read(byte[] source, int sourceOffset, Object dest){
+        this.currentKeyFieldKey.setSource(source);
+
+        int leadByte = 255 & source[sourceOffset++];
+        int fieldType = leadByte >> 4;
+
+        //todo if not object - throw exception
+
+        int lengthLength = leadByte & 15;  // 15 = binary 00001111 - filters out 4 top bits
+
+        if(lengthLength == 0){
+            return null; //object field with value null is always 1 byte long.
+        }
+
+        int length = 255 & source[sourceOffset++];
+        for(int i=1; i<lengthLength; i++){
+            length <<= 8;
+            length |= 255 & source[sourceOffset++];
+        }
+        int endIndex = sourceOffset + length;
+
+        while(sourceOffset < endIndex){
+            leadByte     = 255 & source[sourceOffset++];
+            fieldType    = leadByte >> 4;
+            lengthLength = leadByte & 15;  // 15 = binary 00001111 - filters out 4 top bits
+
+            //todo can this be optimized with a switch statement?
+
+            //expect a key field
+            if(fieldType == RionFieldTypes.KEY || fieldType == RionFieldTypes.KEY_SHORT){
+
+                //distinguish between length and lengthLength depending on compact key field or normal key field
+                length = 0;
+                if(fieldType == RionFieldTypes.KEY_SHORT){
+                    length = leadByte & 15;
+                } else {
+                    for(int i=0; i<lengthLength; i++){
+                        length <<= 8;
+                        length |= 255 & source[sourceOffset++];
+                    }
+                }
+
+                this.currentKeyFieldKey.setOffsets(sourceOffset, length);
+
+                IRionFieldReader reader = this.fieldReaderMap.get(this.currentKeyFieldKey);
+                if(reader == null){
+                    reader = this.nopFieldReader;
+                }
+
+                //find beginning of next field value - then call field reader.
+                sourceOffset += length;
+
+                //todo check for end of object - if found, call reader.setNull() - no value field following the key field.
+
+                int nextLeadByte  = 255 & source[sourceOffset];
+                int nextFieldType = nextLeadByte >> 4;
+
+                if(nextFieldType != RionFieldTypes.KEY && nextFieldType != RionFieldTypes.KEY_SHORT){
+                    sourceOffset += reader.read(source, sourceOffset, dest);
+                } else {
+                    //next field is also a key - meaning the previous key has a value of null (no value field following it).
+                    reader.setNull(dest);
+                }
+            }
+
+        }
+
+        return dest;
+    }
+
+
+
+    private Object instantiateType() {
+        try {
+             return this.typeClass.newInstance();
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return null; //todo remove later when rethrowing exceptions.
+    }
+
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/read/object/RionObjectReaderConfiguratorNopImpl.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/object/RionObjectReaderConfiguratorNopImpl.java
@@ -1,0 +1,14 @@
+package com.nanosai.rionops.rion.read.object;
+
+/**
+ * Created by jjenkov on 10-02-2016.
+ */
+public class RionObjectReaderConfiguratorNopImpl implements IRionObjectReaderConfigurator {
+
+    public static final RionObjectReaderConfiguratorNopImpl DEFAULT_INSTANCE = new RionObjectReaderConfiguratorNopImpl();
+
+    @Override
+    public void configure(RionFieldReaderConfiguration config) {
+        //do nothing.
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/IRionFieldWriter.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/IRionFieldWriter.java
@@ -1,0 +1,13 @@
+package com.nanosai.rionops.rion.write.object;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public interface IRionFieldWriter {
+
+    public int getKeyFieldLength();
+    public int writeKeyField(byte[] destination, int destinationOffset);
+    public int writeValueField(Object sourceObject, byte[] destination, int destinationOffset, int maxLengthLength);
+
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/IRionObjectWriterConfigurator.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/IRionObjectWriterConfigurator.java
@@ -1,0 +1,13 @@
+package com.nanosai.rionops.rion.write.object;
+
+/**
+ * An IRionObjectWriterConfigurator can configure an RionObjectWriter. An implementation of this interface is
+ * passed to the RionObjectWriter's constructor. The RionObjectWriter then calls the IRionObjectWriterConfigurator
+ * for each field in the target class. The IRionObjectWriterConfigurator instance can then set a few configuration
+ * options for the given field (exclude it from serialization, or use another field fieldName (alias))
+ */
+public interface IRionObjectWriterConfigurator {
+
+    public void configure(RionFieldWriterConfiguration config);
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayByte.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayByte.java
@@ -1,0 +1,45 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterArrayByte extends RionFieldWriterBase implements IRionFieldWriter {
+
+    public RionFieldWriterArrayByte(Field field, String alias) {
+        super(field, alias);
+    }
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            byte[] value = (byte[]) field.get(sourceObject);
+
+            if(value == null) {
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.BYTES << 4))); //byte array which is null
+                return 1;
+            }
+
+            int length = value.length;
+
+            int lengthLength = RionUtil.byteLengthOfInt64Value(length);
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.BYTES << 4) | lengthLength) );
+
+            for(int i=(lengthLength-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (length >> i));
+            }
+
+            System.arraycopy(value, 0, dest, destOffset, value.length);
+
+            return 1 + lengthLength + length; //total length of a UTF-8 field
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayDouble.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayDouble.java
@@ -1,0 +1,76 @@
+package com.nanosai.rionops.rion.write.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterArrayDouble extends RionFieldWriterBase implements IRionFieldWriter {
+
+    private static int MAX_ELEMENT_FIELD_LENGTH = 9;    //an ION long field can max be 9 bytes long
+
+    public RionFieldWriterArrayDouble(Field field, String alias) {
+        super(field, alias);
+    }
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            double[] value = (double[]) field.get(sourceObject);
+
+            if(value == null) {
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4))); //byte array which is null
+                return 1;
+            }
+
+            int elementCount = value.length;
+            int elementCountLengthLength = RionUtil.byteLengthOfInt64Value(elementCount);
+            int maxPossibleArrayFieldLength =
+                    1 + elementCountLengthLength +           // +1 for lead byte of element count field (Int64-Pos)
+                    (elementCount * MAX_ELEMENT_FIELD_LENGTH);
+
+            int arrayLengthLength = RionUtil.byteLengthOfInt64Value(maxPossibleArrayFieldLength);
+
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4) | arrayLengthLength) );
+            int lengthStartOffset = destOffset;
+
+            //allocate arrayLengthLength bytes for later - when we know the real length (in bytes) of this ION array field
+            destOffset += arrayLengthLength;
+
+            //write element count
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.INT_POS << 4) | elementCountLengthLength));
+            for(int i=(elementCountLengthLength-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (elementCount >> i));
+            }
+
+            //write elements
+            for(int i=0; i < elementCount; i++){
+                long elementVal = Double.doubleToLongBits(value[i]);
+
+                final int length = 8;
+
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.FLOAT << 4) | length));
+
+                for(int j=(length-1)*8; j >= 0; j-=8){
+                    dest[destOffset++] = (byte) (255 & (elementVal >> j));
+                }
+            }
+
+            //write total length of array
+            int arrayByteLength = destOffset - (lengthStartOffset + arrayLengthLength);
+            for(int i=(arrayLengthLength-1)*8; i >= 0; i-=8){
+                dest[lengthStartOffset++] = (byte) (255 & (arrayByteLength >> i));
+            }
+
+            return 1 + arrayLengthLength + arrayByteLength; //total length of a UTF-8 field
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayFloat.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayFloat.java
@@ -1,0 +1,77 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterArrayFloat extends RionFieldWriterBase implements IRionFieldWriter {
+
+    private static int MAX_ELEMENT_FIELD_LENGTH = 9;    //an ION long field can max be 9 bytes long
+
+    public RionFieldWriterArrayFloat(Field field, String alias) {
+        super(field, alias);
+    }
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            float[] value = (float[]) field.get(sourceObject);
+
+            if(value == null) {
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4))); //byte array which is null
+                return 1;
+            }
+
+            int elementCount = value.length;
+            int elementCountLengthLength = RionUtil.byteLengthOfInt64Value(elementCount);
+            int maxPossibleArrayFieldLength =
+                         1 + elementCountLengthLength +           // +1 for lead byte of element count field (Int64-Pos)
+                    (elementCount * MAX_ELEMENT_FIELD_LENGTH);
+
+            int arrayLengthLength = RionUtil.byteLengthOfInt64Value(maxPossibleArrayFieldLength);
+
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4) | arrayLengthLength) );
+            int lengthStartOffset = destOffset;
+
+            //allocate arrayLengthLength bytes for later - when we know the real length (in bytes) of this ION array field
+            destOffset += arrayLengthLength;
+
+            //write element count
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.INT_POS << 4) | elementCountLengthLength));
+
+            for(int i=(elementCountLengthLength-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (elementCount >> i));
+            }
+
+            //write elements
+            for(int i=0; i < elementCount; i++){
+                int elementVal = Float.floatToIntBits(value[i]);
+
+                final int length = 4;
+
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.FLOAT << 4) | length));
+
+                for(int j=(length-1)*8; j >= 0; j-=8){
+                    dest[destOffset++] = (byte) (255 & (elementVal >> j));
+                }
+            }
+
+            //write total length of array
+            int arrayByteLength = destOffset - (lengthStartOffset + arrayLengthLength);
+            for(int i=(arrayLengthLength-1)*8; i >= 0; i-=8){
+                dest[lengthStartOffset++] = (byte) (255 & (arrayByteLength >> i));
+            }
+
+            return 1 + arrayLengthLength + arrayByteLength; //total length of a UTF-8 field
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayInt.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayInt.java
@@ -1,0 +1,82 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterArrayInt extends RionFieldWriterBase implements IRionFieldWriter {
+
+    private static int MAX_ELEMENT_FIELD_LENGTH           = 9;    //an ION long field can max be 9 bytes long
+
+    public RionFieldWriterArrayInt(Field field, String alias) {
+        super(field, alias);
+    }
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            int[] value = (int[]) field.get(sourceObject);
+
+            if(value == null) {
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4))); //byte array which is null
+                return 1;
+            }
+
+            int elementCount = value.length;
+            int elementCountLengthLength = RionUtil.byteLengthOfInt64Value(elementCount);
+            int maxPossibleFieldLength =
+                         1 + elementCountLengthLength +           // +1 for lead byte of element count field (int64-positive)
+                    (elementCount * MAX_ELEMENT_FIELD_LENGTH);
+
+            int arrayLengthLength = RionUtil.byteLengthOfInt64Value(maxPossibleFieldLength);
+
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4) | arrayLengthLength) );
+            int lengthStartOffset = destOffset;
+
+            //allocate arrayLengthLength bytes for later - when we know the real length (in bytes) of this ION array field
+            destOffset += arrayLengthLength;
+
+            //write element count
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.INT_POS << 4) | elementCountLengthLength));
+            for(int i=(elementCountLengthLength-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (elementCount >> i));
+            }
+
+            //write elements
+            for(int i=0; i < elementCount; i++){
+                int elementVal = value[i];
+
+                int ionFieldType = RionFieldTypes.INT_POS;
+                if(elementVal < 0){
+                    ionFieldType = RionFieldTypes.INT_NEG;
+                    elementVal  = -(elementVal+1);
+                }
+
+                int length = RionUtil.byteLengthOfInt64Value(elementVal);
+
+                dest[destOffset++] = (byte) (255 & ((ionFieldType << 4) | length));
+
+                for(int j=(length-1)*8; j >= 0; j-=8){
+                    dest[destOffset++] = (byte) (255 & (elementVal >> j));
+                }
+            }
+
+            //write total length of array
+            int arrayByteLength = destOffset - (lengthStartOffset + arrayLengthLength);
+            for(int i=(arrayLengthLength-1)*8; i >= 0; i-=8){
+                dest[lengthStartOffset++] = (byte) (255 & (arrayByteLength >> i));
+            }
+
+            return 1 + arrayLengthLength + arrayByteLength; //total length of a UTF-8 field
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayLong.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayLong.java
@@ -1,0 +1,84 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterArrayLong extends RionFieldWriterBase implements IRionFieldWriter {
+
+    private static int MAX_ELEMENT_FIELD_LENGTH = 9;    //an ION long field can max be 9 bytes long
+    private static int COMPLEX_TYPE_ID_SHORT_FIELD_LENGTH = 2;    //an ION long field can max be 9 bytes long
+
+    public RionFieldWriterArrayLong(Field field, String alias) {
+        super(field, alias);
+    }
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            long[] value = (long[]) field.get(sourceObject);
+
+            if(value == null) {
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4))); //byte array which is null
+                return 1;
+            }
+
+            int elementCount = value.length;
+            int elementCountLengthLength = RionUtil.byteLengthOfInt64Value(elementCount);
+            int maxPossibleFieldLength =
+                         1 + elementCountLengthLength +           // +1 for lead byte of element count field (Int64-Pos)
+                    (elementCount * MAX_ELEMENT_FIELD_LENGTH);
+
+            int arrayLengthLength = RionUtil.byteLengthOfInt64Value(maxPossibleFieldLength);
+
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4) | arrayLengthLength) );
+            int lengthStartOffset = destOffset;
+
+            //allocate arrayLengthLength bytes for later - when we know the real length (in bytes) of this ION array field
+            destOffset += arrayLengthLength;
+
+            //write element count
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.INT_POS << 4) | elementCountLengthLength));
+            for(int i=(elementCountLengthLength-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (elementCount >> i));
+            }
+
+            //write elements
+            for(int i=0; i < elementCount; i++){
+                long elementVal = value[i];
+
+                int ionFieldType = RionFieldTypes.INT_POS;
+                if(elementVal < 0){
+                    ionFieldType = RionFieldTypes.INT_NEG;
+                    elementVal  = -(elementVal+1);
+                }
+
+                int length = RionUtil.byteLengthOfInt64Value(elementVal);
+
+                dest[destOffset++] = (byte) (255 & ((ionFieldType << 4) | length));
+
+                for(int j=(length-1)*8; j >= 0; j-=8){
+                    dest[destOffset++] = (byte) (255 & (elementVal >> j));
+                }
+            }
+
+            //write total length of array
+            int arrayByteLength = destOffset - (lengthStartOffset + arrayLengthLength);
+            for(int i=(arrayLengthLength-1)*8; i >= 0; i-=8){
+                dest[lengthStartOffset++] = (byte) (255 & (arrayByteLength >> i));
+            }
+
+            return 1 + arrayLengthLength + arrayByteLength; //total length of a UTF-8 field
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayShort.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterArrayShort.java
@@ -1,0 +1,85 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterArrayShort extends RionFieldWriterBase implements IRionFieldWriter {
+
+    private static int MAX_ELEMENT_FIELD_LENGTH           = 9;    //an ION long field can max be 9 bytes long
+    private static int COMPLEX_TYPE_ID_SHORT_FIELD_LENGTH = 2;    //an ION long field can max be 9 bytes long
+
+    public RionFieldWriterArrayShort(Field field, String alias) {
+        super(field, alias);
+    }
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            short[] value = (short[]) field.get(sourceObject);
+
+            if(value == null) {
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4))); //byte array which is null
+                return 1;
+            }
+
+            int elementCount = value.length;
+            int elementCountLengthLength = RionUtil.byteLengthOfInt64Value(elementCount);
+            int maxPossibleFieldLength =
+                    COMPLEX_TYPE_ID_SHORT_FIELD_LENGTH +          // 2 bytes for complex type id field
+                         1 + elementCountLengthLength +           // +1 for lead byte of element count field (int64-positive)
+                    (elementCount * MAX_ELEMENT_FIELD_LENGTH);
+
+            int arrayLengthLength = RionUtil.byteLengthOfInt64Value(maxPossibleFieldLength);
+
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.ARRAY << 4) | arrayLengthLength) );
+            int lengthStartOffset = destOffset;
+
+            //allocate arrayLengthLength bytes for later - when we know the real length (in bytes) of this ION array field
+            destOffset += arrayLengthLength;
+
+            //write element count
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.INT_POS << 4) | elementCountLengthLength) );
+            for(int i=(elementCountLengthLength-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (elementCount >> i));
+            }
+
+            //write elements
+            for(int i=0; i < elementCount; i++){
+                short elementVal = value[i];
+
+                int ionFieldType = RionFieldTypes.INT_POS;
+                if(elementVal < 0){
+                    ionFieldType = RionFieldTypes.INT_NEG;
+                    elementVal  = (short) -(elementVal+1);
+                }
+
+                int length = RionUtil.byteLengthOfInt64Value(elementVal);
+
+                dest[destOffset++] = (byte) (255 & ((ionFieldType << 4) | length));
+
+                for(int j=(length-1)*8; j >= 0; j-=8){
+                    dest[destOffset++] = (byte) (255 & (elementVal >> j));
+                }
+            }
+
+            //write total length of array
+            int arrayByteLength = destOffset - (lengthStartOffset + arrayLengthLength);
+            for(int i=(arrayLengthLength-1)*8; i >= 0; i-=8){
+                dest[lengthStartOffset++] = (byte) (255 & (arrayByteLength >> i));
+            }
+
+            return 1 + arrayLengthLength + arrayByteLength; //total length of a UTF-8 field
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterBase.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterBase.java
@@ -1,0 +1,33 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import java.lang.reflect.Field;
+
+/**
+ * This class is a base class for IRionFieldWriter implementations.
+ *
+ */
+public abstract class RionFieldWriterBase implements IRionFieldWriter {
+
+    protected Field  field    = null;
+    protected byte[] keyField = null;
+
+    public RionFieldWriterBase(Field field, String alias) {
+        this.field = field;
+        this.keyField = RionFieldWriterUtil.preGenerateKeyField(alias);
+    }
+
+    @Override
+    public int getKeyFieldLength() {
+        return this.keyField.length;
+    }
+
+    @Override
+    public int writeKeyField(byte[] destination, int destinationOffset) {
+        System.arraycopy(this.keyField, 0, destination, destinationOffset, this.keyField.length);
+        return this.keyField.length;
+    }
+
+    @Override
+    public abstract int writeValueField(Object sourceObject, byte[] destination, int destinationOffset, int maxLengthLength);
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterBoolean.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterBoolean.java
@@ -1,0 +1,35 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterBoolean extends RionFieldWriterBase implements IRionFieldWriter {
+
+    public RionFieldWriterBoolean(Field field, String alias) {
+        super(field, alias);
+    }
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] destination, int destinationOffset, int maxLengthLength) {
+        try {
+            boolean value = (Boolean) field.get(sourceObject);
+
+            if(value){
+                destination[destinationOffset] = (byte) (255 & ((RionFieldTypes.BOOLEAN << 4) | 1));
+            } else {
+                destination[destinationOffset] = (byte) (255 & ((RionFieldTypes.BOOLEAN << 4) | 2));
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 1;    //total length of a boolean field is always 1
+    }
+
+
+ }

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterByte.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterByte.java
@@ -1,0 +1,44 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterByte extends RionFieldWriterBase implements IRionFieldWriter {
+
+    public RionFieldWriterByte(Field field, String alias) {
+        super(field, alias);
+    }
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            long value = (byte) field.get(sourceObject);
+            int ionFieldType = RionFieldTypes.INT_POS;
+            if(value < 0){
+                ionFieldType = RionFieldTypes.INT_NEG;
+                value  = -(value+1);
+            }
+
+            int length = RionUtil.byteLengthOfInt64Value(value);
+
+            dest[destOffset++] = (byte) (255 & ((ionFieldType << 4) | length));
+
+            for(int i=(length-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (value >> i));
+            }
+
+            return 1 + length;
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterCalendar.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterCalendar.java
@@ -1,0 +1,67 @@
+package com.nanosai.rionops.rion.write.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+import java.util.Calendar;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterCalendar extends RionFieldWriterBase implements IRionFieldWriter {
+
+    protected int length = 7;
+
+    public RionFieldWriterCalendar(Field field, String alias) {
+        super(field, alias);
+    }
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            Calendar value = (Calendar) field.get(sourceObject);
+
+            if(value == null){
+                dest[destOffset++] = (byte) (255 & (RionFieldTypes.UTC_DATE_TIME << 4));
+                return 1;
+            }
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.UTC_DATE_TIME << 4) | length));
+
+            int year = value.get(Calendar.YEAR);
+            dest[destOffset++] = (byte) (255 & (year >>   8));
+            dest[destOffset++] = (byte) (255 & (year &  255));
+
+            if(length == 2) { return 3;}  // 1 + length (2)
+
+            dest[destOffset++] = (byte) (255 & (value.get(Calendar.MONTH) + 1));
+
+            if(length == 3) { return 4;}  // 1 + length (3)
+
+            dest[destOffset++] = (byte) (255 & (value.get(Calendar.DAY_OF_MONTH)));
+
+            if(length == 4) { return 5;}  // 1 + length (4)
+
+            dest[destOffset++] = (byte) (255 & (value.get(Calendar.HOUR_OF_DAY)));
+
+            if(length == 5) { return 6;}  // 1 + length (5)
+
+            dest[destOffset++] = (byte) (255 & (value.get(Calendar.MINUTE)));
+
+            if(length == 6) { return 7;}  // 1 + length (6)
+
+            dest[destOffset++] = (byte) (255 & (value.get(Calendar.SECOND)));
+
+            if(length == 7) { return 8;}  // 1 + length (7)
+
+            int millis =  value.get(Calendar.MILLISECOND);
+            dest[destOffset++] = (byte) (255 & (millis >>  8));
+            dest[destOffset++] = (byte) (255 & (millis));
+
+            return 10;  // 1 + length (9)
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterConfiguration.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterConfiguration.java
@@ -1,0 +1,29 @@
+package com.nanosai.rionops.rion.write.object;
+
+import java.lang.reflect.Field;
+
+/**
+ * A configuration for a single IRionFieldWriter (used internally by the RionObjectWriter).
+ *
+ * An IRionObjectWriterConfigurator can read the <code>field</code> field to see what field (field writer)
+ * this configuration is for.
+ *
+ * The fieldName of the field is stored in the <code>fieldName</code> field (but is also accessible
+ * via field.getName()).
+ *
+ * The <code>include</code> field defaults to true, but can be set to false. The RionObjectWriter will then not
+ * include a field writer for this field, meaning that field will not be included in the written ION data.
+ *
+ * The <code>alias</code> field can be used to give the field a different fieldName in the written ION data than the
+ * field has in the Java object.
+ */
+public class RionFieldWriterConfiguration {
+    public Field   field    = null;
+    public String fieldName = null;
+
+
+    public boolean include = true;
+    public String  alias   = null;
+
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterDouble.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterDouble.java
@@ -1,0 +1,37 @@
+package com.nanosai.rionops.rion.write.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterDouble extends RionFieldWriterBase implements IRionFieldWriter {
+
+    public RionFieldWriterDouble(Field field, String alias) {
+        super(field, alias);
+    }
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            double value = (double) field.get(sourceObject);
+            long valueLongBits = Double.doubleToLongBits(value);
+
+            //magic number "8" is the length in bytes of a 32 bit floating point number in ION.
+
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.FLOAT << 4) | 8));
+
+            for(int i=(8-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (valueLongBits >> i));
+            }
+
+            return 9;
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterFloat.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterFloat.java
@@ -1,0 +1,39 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterFloat extends RionFieldWriterBase implements IRionFieldWriter {
+
+
+    public RionFieldWriterFloat(Field field, String alias) {
+        super(field, alias);
+    }
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            float value = (float) field.get(sourceObject);
+            int valueIntBits = Float.floatToIntBits(value);
+
+            //magic number "4" is the length in bytes of a 32 bit floating point number in ION.
+
+            dest[destOffset++] = (byte) (255 & ((RionFieldTypes.FLOAT << 4) | 4));
+
+            for(int i=(4-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (valueIntBits >> i));
+            }
+
+            return 5;
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterInt.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterInt.java
@@ -1,0 +1,45 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterInt extends RionFieldWriterBase implements IRionFieldWriter {
+
+    public RionFieldWriterInt(Field field, String alias) {
+        super(field, alias);
+    }
+
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            long value = (int) field.get(sourceObject);
+            int ionFieldType = RionFieldTypes.INT_POS;
+            if(value < 0){
+                ionFieldType = RionFieldTypes.INT_NEG;
+                value  = -(value+1);
+            }
+
+            int length = RionUtil.byteLengthOfInt64Value(value);
+
+            dest[destOffset++] = (byte) (255 & ((ionFieldType << 4) | length));
+
+            for(int i=(length-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (value >> i));
+            }
+
+            return 1 + length;
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterLong.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterLong.java
@@ -1,0 +1,43 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterLong extends RionFieldWriterBase implements IRionFieldWriter {
+
+    public RionFieldWriterLong(Field field, String alias) {
+        super(field, alias);
+    }
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            long value = (long) field.get(sourceObject);
+            int ionFieldType = RionFieldTypes.INT_POS;
+            if(value < 0){
+                ionFieldType = RionFieldTypes.INT_NEG;
+                value  = -(value+1);
+            }
+
+            int length = RionUtil.byteLengthOfInt64Value(value);
+
+            dest[destOffset++] = (byte) (255 & ((ionFieldType << 4) | length));
+
+            for(int i=(length-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (value >> i));
+            }
+
+            return 1 + length;
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterObject.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterObject.java
@@ -1,0 +1,70 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterObject extends RionFieldWriterBase implements IRionFieldWriter {
+
+    public Field[] fields    = null;
+
+    public IRionFieldWriter[] fieldWriters = null;
+
+    public RionFieldWriterObject(Field field, String alias) {
+        super(field, alias);
+    }
+
+    public void generateFieldWriters(IRionObjectWriterConfigurator configurator, Map<Field, IRionFieldWriter> existingFieldWriters) {
+        //generate field writers for this RionFieldWriterObject instance - fields in the class of this field.
+        this.fieldWriters = RionFieldWriterUtil.createFieldWriters(field.getType().getDeclaredFields(), configurator, existingFieldWriters);
+    }
+
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] destination, int destinationOffset, int maxLengthLength) {
+
+        try {
+            Object fieldValue = this.field.get(sourceObject);
+            if(fieldValue == null){
+                destination[destinationOffset++] = (byte) (255 & ((RionFieldTypes.OBJECT << 4) | 0)); //marks a null with 0 lengthLength
+                return 1;
+            }
+
+            destination[destinationOffset++] = (byte) (255 & ((RionFieldTypes.OBJECT << 4) | maxLengthLength));
+
+            int lengthOffset   = destinationOffset; //store length start offset for later use
+            destinationOffset += maxLengthLength;
+
+
+            for(int i=0; i<fieldWriters.length; i++){
+                if(fieldWriters[i] != null){
+                    destinationOffset += fieldWriters[i].writeKeyField(destination, destinationOffset);
+                    destinationOffset += fieldWriters[i].writeValueField(fieldValue, destination, destinationOffset, maxLengthLength);
+                }
+            }
+
+            int fullFieldLength   = destinationOffset - (lengthOffset + maxLengthLength);
+
+            switch(maxLengthLength){
+                case 4 : destination[lengthOffset++] = (byte) (255 & (fullFieldLength >> 24));
+                case 3 : destination[lengthOffset++] = (byte) (255 & (fullFieldLength >> 16));
+                case 2 : destination[lengthOffset++] = (byte) (255 & (fullFieldLength >>  8));
+                case 1 : destination[lengthOffset++] = (byte) (255 & (fullFieldLength));
+            }
+
+            return 1 + maxLengthLength + fullFieldLength;
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+            //todo should never happen, as we set all Field instances to accessible.
+        }
+
+        return 0;
+    }
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterShort.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterShort.java
@@ -1,0 +1,45 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterShort extends RionFieldWriterBase implements IRionFieldWriter {
+
+
+    public RionFieldWriterShort(Field field, String alias) {
+        super(field, alias);
+    }
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            long value = (short) field.get(sourceObject);
+            int ionFieldType = RionFieldTypes.INT_POS;
+            if(value < 0){
+                ionFieldType = RionFieldTypes.INT_NEG;
+                value  = -(value+1);
+            }
+
+            int length = RionUtil.byteLengthOfInt64Value(value);
+
+            dest[destOffset++] = (byte) (255 & ((ionFieldType << 4) | length));
+
+            for(int i=(length-1)*8; i >= 0; i-=8){
+                dest[destOffset++] = (byte) (255 & (value >> i));
+            }
+
+            return 1 + length;
+
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterString.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterString.java
@@ -1,0 +1,60 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterString extends RionFieldWriterBase implements IRionFieldWriter {
+
+    public RionFieldWriterString(Field field, String alias) {
+        super(field, alias);
+    }
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] dest, int destOffset, int maxLengthLength) {
+        try {
+            String value = (String) field.get(sourceObject);
+
+            if(value == null){
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.UTF_8_SHORT << 4) | 0));
+                return 1;
+            }
+
+            //todo optimize this - do not get bytes from a string like this. UTF-8 encode char-for-char with charAt() instead.
+            byte[] valueBytes = value.getBytes("UTF-8");
+
+
+            int length = valueBytes.length;
+
+            if(length <= 15){
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.UTF_8_SHORT << 4) | length) );
+                System.arraycopy(valueBytes, 0, dest, destOffset, valueBytes.length);
+
+                return 1 + length;
+            } else {
+                int lengthLength = RionUtil.byteLengthOfInt64Value(length);
+                dest[destOffset++] = (byte) (255 & ((RionFieldTypes.UTF_8 << 4) | lengthLength) );
+
+                for(int i=(lengthLength-1)*8; i >= 0; i-=8){
+                    dest[destOffset++] = (byte) (255 & (length >> i));
+                }
+
+                System.arraycopy(valueBytes, 0, dest, destOffset, valueBytes.length);
+
+                return 1 + lengthLength + length; //total length of a UTF-8 field
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+            //will never happen - UTF-8 always supported
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterTable.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterTable.java
@@ -1,0 +1,100 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class RionFieldWriterTable extends RionFieldWriterBase implements IRionFieldWriter {
+
+    protected byte[] allKeyFieldBytes = null;
+    protected IRionFieldWriter[] fieldWritersForArrayType = null;
+
+
+    public RionFieldWriterTable(Field field, String alias) {
+        super(field, alias);
+    }
+
+    public void generateFieldWriters(IRionObjectWriterConfigurator configurator, Map<Field, IRionFieldWriter> existingFieldWriters) {
+        this.fieldWritersForArrayType = RionFieldWriterUtil.createFieldWriters(
+                this.field.getType().getComponentType().getDeclaredFields(), configurator, existingFieldWriters);
+
+        preGenerateAllKeyFields();
+    }
+
+    private void preGenerateAllKeyFields() {
+        int totalKeyFieldsLength = 0;
+
+        for(int i=0; i < this.fieldWritersForArrayType.length; i++){
+            totalKeyFieldsLength += this.fieldWritersForArrayType[i].getKeyFieldLength();
+        }
+
+        allKeyFieldBytes = new byte[totalKeyFieldsLength];
+
+        int offset = 0;
+        for(int i=0; i < this.fieldWritersForArrayType.length; i++){
+            offset += this.fieldWritersForArrayType[i].writeKeyField(allKeyFieldBytes, offset);
+        }
+
+    }
+
+
+
+
+    @Override
+    public int writeValueField(Object sourceObject, byte[] destination, int destinationOffset, int maxLengthLength) {
+
+        try {
+            Object array = (Object) field.get(sourceObject);
+
+            if(array == null) {
+                destination[destinationOffset++] = (byte) (255 & ((RionFieldTypes.TABLE << 4) | 0)); //marks a null with 0 lengthLength
+                return 1;
+            }
+            int startIndex = destinationOffset;
+            destination[destinationOffset] = (byte) (255 & (RionFieldTypes.TABLE << 4) | (maxLengthLength));
+            destinationOffset += 1 + maxLengthLength ; // 1 for lead byte + make space for maxLengthLength length bytes.
+
+            //write element count
+            int elementCount = Array.getLength(array);
+            int elementCountLengthLength = RionUtil.byteLengthOfInt64Value(elementCount);
+
+            destination[destinationOffset++] = (byte) (255 & ((RionFieldTypes.INT_POS << 4) | elementCountLengthLength) );
+            for(int i=(elementCountLengthLength-1)*8; i >= 0; i-=8){
+                destination[destinationOffset++] = (byte) (255 & (elementCount >> i));
+            }
+
+
+            //write key fields
+            System.arraycopy(this.allKeyFieldBytes, 0, destination, destinationOffset, this.allKeyFieldBytes.length);
+            destinationOffset += this.allKeyFieldBytes.length;
+
+
+            //write array elements
+            for(int i=0; i<elementCount; i++){
+                Object source = Array.get(array, i);
+
+                //for each field in source write its field value out.
+                for(int j=0; j < this.fieldWritersForArrayType.length; j++){
+                    destinationOffset += this.fieldWritersForArrayType[j].writeValueField(source, destination, destinationOffset, maxLengthLength);
+                }
+            }
+
+            int valueLength = destinationOffset - startIndex;
+
+            RionFieldWriterUtil.writeLength(valueLength - 1 - maxLengthLength, maxLengthLength, destination, startIndex + 1);
+
+            return valueLength;
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 0;
+    }
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterUtil.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionFieldWriterUtil.java
@@ -1,0 +1,165 @@
+package com.nanosai.rionops.rion.write.object;
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.RionUtil;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.util.*;
+
+public class RionFieldWriterUtil {
+
+    public static byte[] preGenerateKeyField(String fieldNameStr) {
+        byte[] keyField  = null;
+        try {
+            byte[] fieldName = fieldNameStr.getBytes("UTF-8");
+
+            int fieldNameLength = fieldName.length;
+            if(fieldNameLength <= 15){
+                keyField = new byte[1 + fieldName.length];
+                keyField[0] = (byte) (255 & ((RionFieldTypes.KEY_SHORT << 4) | fieldName.length));
+                System.arraycopy(fieldName, 0, keyField, 1, fieldName.length);
+            } else {
+                int length = fieldName.length;
+                int lengthLength = RionUtil.byteLengthOfInt64Value(length);
+                keyField = new byte[1 + lengthLength + fieldName.length];
+
+                keyField[0] = (byte) (255 & ((RionFieldTypes.KEY << 4) | lengthLength));
+                int destOffset = 1;
+                for(int i=(lengthLength-1)*8; i >= 0; i-=8){
+                    keyField[destOffset++] = (byte) (255 & (length >> i));
+                }
+
+                System.arraycopy(fieldName, 0, keyField, destOffset, fieldName.length);
+            }
+
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+            //will never happen - UTF-8 is always supported.
+        }
+
+        return keyField;
+    }
+
+
+
+    public static IRionFieldWriter[] createFieldWriters(
+            Field[] fields, IRionObjectWriterConfigurator configurator,
+            Map<Field, IRionFieldWriter> existingFieldWriters) {
+        List<IRionFieldWriter> fieldWritersTemp = new ArrayList<>();
+
+        RionFieldWriterConfiguration fieldConfiguration = new RionFieldWriterConfiguration();
+
+        for(int i=0; i < fields.length; i++){
+            if(existingFieldWriters.containsKey(fields[i])){
+                IRionFieldWriter fieldWriter = existingFieldWriters.get(fields[i]);
+                fieldWritersTemp.add(fieldWriter);
+                continue;
+            }
+
+            fieldConfiguration.field     = fields[i];
+            fieldConfiguration.fieldName = fields[i].getName();
+            fieldConfiguration.alias     = fields[i].getName();
+            fieldConfiguration.include   = true;
+
+            configurator.configure(fieldConfiguration);
+
+            if(fieldConfiguration.include){
+                IRionFieldWriter fieldWriter =
+                        RionFieldWriterUtil.createFieldWriter(fields[i], fieldConfiguration.alias, configurator, existingFieldWriters);
+
+                existingFieldWriters.put(fields[i], fieldWriter);
+
+                if(fieldWriter instanceof RionFieldWriterObject){
+                    ((RionFieldWriterObject) fieldWriter).generateFieldWriters(configurator, existingFieldWriters);
+                } else if(fieldWriter instanceof RionFieldWriterTable){
+                    ((RionFieldWriterTable) fieldWriter).generateFieldWriters(configurator, existingFieldWriters);
+                }
+                fieldWritersTemp.add(fieldWriter);
+            }
+        }
+
+        IRionFieldWriter[] fieldWriters = new IRionFieldWriter[fieldWritersTemp.size()];
+
+        for(int i=0, n=fieldWritersTemp.size(); i < n; i++){
+            fieldWriters[i] = fieldWritersTemp.get(i);
+        }
+
+        return fieldWriters;
+    }
+
+    public static IRionFieldWriter createFieldWriter(Field field, String alias, IRionObjectWriterConfigurator configurator, Map<Field, IRionFieldWriter> existingFieldWriters){
+        field.setAccessible(true); //allows access to private fields, and supposedly speeds up reflection...  ?
+        Class fieldType = field.getType();
+
+        if(boolean.class.equals(fieldType)){
+            return new RionFieldWriterBoolean(field, alias);
+        }
+        if(byte.class.equals(fieldType)){
+            return new RionFieldWriterByte(field, alias);
+        }
+        if(short.class.equals(fieldType)){
+            return new RionFieldWriterShort(field, alias);
+        }
+        if(int.class.equals(fieldType)){
+            return new RionFieldWriterInt(field, alias);
+        }
+        if(long.class.equals(fieldType)){
+            return new RionFieldWriterLong(field, alias);
+        }
+        if(float.class.equals(fieldType)){
+            return new RionFieldWriterFloat(field, alias);
+        }
+        if(double.class.equals(fieldType)){
+            return new RionFieldWriterDouble(field, alias);
+        }
+        if(String.class.equals(fieldType)){
+            return new RionFieldWriterString(field, alias);
+        }
+        if(Calendar.class.equals(fieldType)){
+            return new RionFieldWriterCalendar(field, alias);
+        }
+        if(GregorianCalendar.class.equals(fieldType)){
+            return new RionFieldWriterCalendar(field, alias);
+        }
+        if(fieldType.isArray()){
+            if(byte.class.equals(fieldType.getComponentType())){
+                return new RionFieldWriterArrayByte(field, alias);
+            }
+            if(short.class.equals(fieldType.getComponentType())){
+                return new RionFieldWriterArrayShort(field, alias);
+            }
+            if(int.class.equals(fieldType.getComponentType())){
+                return new RionFieldWriterArrayInt(field, alias);
+            }
+            if(long.class.equals(fieldType.getComponentType())){
+                return new RionFieldWriterArrayLong(field, alias);
+            }
+            if(float.class.equals(fieldType.getComponentType())){
+                return new RionFieldWriterArrayFloat(field, alias);
+            }
+            if(double.class.equals(fieldType.getComponentType())){
+                return new RionFieldWriterArrayDouble(field, alias);
+            }
+            return new RionFieldWriterTable(field, alias);
+        }
+
+        return new RionFieldWriterObject(field, alias);
+    }
+
+    public static void writeLength(long length, int lengthLength, byte[] destination, int destinationOffset){
+        switch(lengthLength){
+            case 8 : { destination[destinationOffset++] = (byte) (255 & (length >> 56));}
+            case 7 : { destination[destinationOffset++] = (byte) (255 & (length >> 48));}
+            case 6 : { destination[destinationOffset++] = (byte) (255 & (length >> 40));}
+            case 5 : { destination[destinationOffset++] = (byte) (255 & (length >> 32));}
+            case 4 : { destination[destinationOffset++] = (byte) (255 & (length >> 24));}
+            case 3 : { destination[destinationOffset++] = (byte) (255 & (length >> 16));}
+            case 2 : { destination[destinationOffset++] = (byte) (255 & (length >>  8));}
+            case 1 : { destination[destinationOffset++] = (byte) (255 &  length );}
+            default : { }  //don't write anything - no length bytes to write, or invalid lengthLength (> 8)
+        }
+    }
+
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionObjectWriter.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionObjectWriter.java
@@ -1,0 +1,75 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+
+import java.util.HashMap;
+
+/**
+ * An RionObjectWriter instance can write an object (instance) of some class to ION data ("ionize" the object in other words).
+ * An RionObjectWriter is targeted at a single Java class. To serialize objects of multiple classes, create one RionObjectWriter
+ * per class.
+ *
+ */
+public class RionObjectWriter {
+
+    public Class   typeClass = null;
+    public IRionFieldWriter[] fieldWriters = null;
+
+    /**
+     * Creates an RionObjectWriter targeted at the class passed as parameter to this constructor.
+     *
+     * @param typeClass The class this RionObjectWriter should be able to write instances of (to ION).
+     */
+
+    public RionObjectWriter(Class typeClass) {
+        this(typeClass, RionObjectWriterConfiguratorNopImpl.DEFAULT_INSTANCE);
+    }
+
+
+    /**
+     * Creates an RionObjectWriter targeted at the class passed as parameter to this constructor.
+     * The IRionObjectWriterConfigurator can configure (modify) this RionObjectWriter instance. For instance,
+     * it can signal that some fields should not be included when writing the object, or modify what field
+     * fieldName is to be used when writing the object.
+     *
+     * @param typeClass    The class this RionObjectWriter should be able to write instances of (to ION).
+     * @param configurator The configurator that can configure each field writer (one per field of the target class) in this RionObjectWriter - even exclude them.
+     */
+    public RionObjectWriter(Class typeClass, IRionObjectWriterConfigurator configurator){
+        this.typeClass = typeClass;
+
+        this.fieldWriters = RionFieldWriterUtil.createFieldWriters(this.typeClass.getDeclaredFields(), configurator, new HashMap<>());
+    }
+
+
+    public int writeObject(Object src, int maxLengthLength, byte[] destination, int destinationOffset){
+        destination[destinationOffset++] = (byte) (255 & ((RionFieldTypes.OBJECT << 4) | maxLengthLength));
+
+        int lengthOffset   = destinationOffset; //store length start offset for later use
+        destinationOffset += maxLengthLength;
+
+
+        for(int i=0; i<fieldWriters.length; i++){
+            if(fieldWriters[i] != null){
+                destinationOffset += fieldWriters[i].writeKeyField(destination, destinationOffset);
+                destinationOffset += fieldWriters[i].writeValueField(src, destination, destinationOffset, maxLengthLength);
+            }
+        }
+
+        int fullFieldLength   = destinationOffset - (lengthOffset + maxLengthLength);
+
+        switch(maxLengthLength){
+            case 4 : destination[lengthOffset++] = (byte) (255 & (fullFieldLength >> 24));
+            case 3 : destination[lengthOffset++] = (byte) (255 & (fullFieldLength >> 16));
+            case 2 : destination[lengthOffset++] = (byte) (255 & (fullFieldLength >>  8));
+            case 1 : destination[lengthOffset++] = (byte) (255 & (fullFieldLength));
+        }
+
+        return 1 + maxLengthLength + fullFieldLength;
+    }
+
+
+
+
+}

--- a/src/main/java/com/nanosai/rionops/rion/write/object/RionObjectWriterConfiguratorNopImpl.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/object/RionObjectWriterConfiguratorNopImpl.java
@@ -1,0 +1,14 @@
+package com.nanosai.rionops.rion.write.object;
+
+/**
+ * Created by jjenkov on 10-02-2016.
+ */
+public class RionObjectWriterConfiguratorNopImpl implements IRionObjectWriterConfigurator {
+
+    public static final RionObjectWriterConfiguratorNopImpl DEFAULT_INSTANCE = new RionObjectWriterConfiguratorNopImpl();
+
+    @Override
+    public void configure(RionFieldWriterConfiguration config) {
+        //do nothing.
+    }
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/Pojo10Float.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/Pojo10Float.java
@@ -1,0 +1,22 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 16-11-2015.
+ */
+public class Pojo10Float {
+    public float field0 = 1.1F;
+    public float field1 = 12.12F;
+    public float field2 = 123.123F;
+    public float field3 = 1234.1234F;
+    public float field4 = 12345.12345F;
+    public float field5 = -1.1F;
+    public float field6 = -12.12F;
+    public float field7 = -123.123F;
+    public float field8 = -1234.1234F;
+    public float field9 = -12345.12345F;
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/Pojo10Int.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/Pojo10Int.java
@@ -1,0 +1,19 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 10-12-2015.
+ */
+public class Pojo10Int {
+
+    public int field0 = 0;
+    public int field1 = 1;
+    public int field2 = 2;
+    public int field3 = 3;
+    public int field4 = 4;
+    public int field5 = 5;
+    public int field6 = 6;
+    public int field7 = 7;
+    public int field8 = 8;
+    public int field9 = 9;
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/PojoArray10Float.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/PojoArray10Float.java
@@ -1,0 +1,26 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 16-11-2015.
+ */
+public class PojoArray10Float {
+
+    public Pojo10Float[] pojos = null;
+
+    public PojoArray10Float() {
+
+    }
+
+    public PojoArray10Float(int count) {
+        this.pojos = new Pojo10Float[count];
+        for(int i=0; i < count; i++){
+            this.pojos[i] = new Pojo10Float();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " (" + this.pojos.length + ")";
+    }
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayByte.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayByte.java
@@ -1,0 +1,9 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 11-12-2015.
+ */
+public class PojoArrayByte {
+
+    public byte[] bytes = null;
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayDouble.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayDouble.java
@@ -1,0 +1,9 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 11-12-2015.
+ */
+public class PojoArrayDouble {
+
+    public double[] doubles = null;
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayFloat.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayFloat.java
@@ -1,0 +1,9 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 11-12-2015.
+ */
+public class PojoArrayFloat {
+
+    public float[] floats = null;
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayInt.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayInt.java
@@ -1,0 +1,9 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 11-12-2015.
+ */
+public class PojoArrayInt {
+
+    public int[] ints = null;
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayLong.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayLong.java
@@ -1,0 +1,9 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 11-12-2015.
+ */
+public class PojoArrayLong {
+
+    public long[] longs = null;
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayShort.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/PojoArrayShort.java
@@ -1,0 +1,9 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 11-12-2015.
+ */
+public class PojoArrayShort {
+
+    public short[] shorts = null;
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/PojoWithPojo.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/PojoWithPojo.java
@@ -1,0 +1,11 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 10-12-2015.
+ */
+public class PojoWithPojo {
+
+    public Pojo10Int field0 = new Pojo10Int();
+
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/RecursiveArrayPojo.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/RecursiveArrayPojo.java
@@ -1,0 +1,27 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 18/03/2017.
+ */
+public class RecursiveArrayPojo {
+
+    private String name = null;
+
+    private RecursiveArrayPojo[] children = null;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public RecursiveArrayPojo[] getChildren() {
+        return children;
+    }
+
+    public void setChildren(RecursiveArrayPojo[] children) {
+        this.children = children;
+    }
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/RecursivePojo.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/RecursivePojo.java
@@ -1,0 +1,33 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 18/03/2017.
+ */
+public class RecursivePojo {
+
+    private String name = null;
+
+    private RecursivePojo child1 = null;
+    private RecursivePojo child2 = null;
+
+    public String getName() { return name; }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public RecursivePojo getChild1() {
+        return child1;
+    }
+
+    public void setChild1(RecursivePojo child1) {
+        this.child1 = child1;
+    }
+
+    public RecursivePojo getChild2() {
+        return child2;
+    }
+
+    public void setChild2(RecursivePojo child2) {
+        this.child2 = child2;
+    }
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/SmallPojo.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/SmallPojo.java
@@ -1,0 +1,11 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 03-02-2016.
+ */
+public class SmallPojo {
+    public boolean field0 = true;
+    public long    field1 = 1234;
+    public float   field2 = 123.12F;
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/TestPojo.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/TestPojo.java
@@ -1,0 +1,22 @@
+package com.nanosai.rionops.rion.pojo;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+/**
+ * Created by jjenkov on 03-11-2015.
+ */
+public class TestPojo {
+
+    public boolean field0 = true;
+    public long    field1 = 1234;
+    public float   field2 = 123.12F;
+    public double  field3 = 123456.1234D;
+    public String  field4 = "abcdefg";
+    public String  field5 = "0123456789012345";
+
+    public Calendar field6 = new GregorianCalendar();
+
+
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/pojo/TestPojoArray.java
+++ b/src/test/java/com/nanosai/rionops/rion/pojo/TestPojoArray.java
@@ -1,0 +1,19 @@
+package com.nanosai.rionops.rion.pojo;
+
+/**
+ * Created by jjenkov on 10-11-2015.
+ */
+public class TestPojoArray {
+
+    public static class TestObject{
+        public boolean field0   = true;
+        public short   field1   = 1;
+        public int     field2   = 12;
+        public long    field3   = 123;
+        public float   field4   = 1234.12F;
+        public TestObject() {}
+    }
+
+    public TestObject[] testObjects = new TestObject[0];
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/read/object/IonObjectReaderRecursivePojoTest.java
+++ b/src/test/java/com/nanosai/rionops/rion/read/object/IonObjectReaderRecursivePojoTest.java
@@ -1,0 +1,90 @@
+package com.nanosai.rionops.rion.read.object;
+
+import com.nanosai.rionops.rion.pojo.RecursiveArrayPojo;
+import com.nanosai.rionops.rion.pojo.RecursivePojo;
+import com.nanosai.rionops.rion.write.object.RionObjectWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Created by jjenkov on 25/03/2017.
+ */
+public class IonObjectReaderRecursivePojoTest {
+
+    @Test
+    public void testRecursiveObjectReading() {
+        byte[] data = new byte[1024];
+        RionObjectWriter ionObjectWriter = new RionObjectWriter(RecursivePojo.class);
+        RionObjectReader rionObjectReader = new RionObjectReader(RecursivePojo.class);
+
+        RecursivePojo pojoSource = new RecursivePojo();
+        pojoSource.setName("root");
+
+        RecursivePojo pojoSourceChild1 = new RecursivePojo();
+        pojoSourceChild1.setName("child1");
+
+        RecursivePojo pojoSourceChild2 = new RecursivePojo();
+        pojoSourceChild2.setName("child2");
+
+        pojoSource.setChild1(pojoSourceChild1);
+        pojoSource.setChild2(pojoSourceChild2);
+
+        ionObjectWriter.writeObject(pojoSource, 2, data, 0);
+
+        RecursivePojo pojoDest = (RecursivePojo) rionObjectReader.read(data, 0);
+        assertNotNull(pojoDest);
+        assertEquals("root", pojoDest.getName());
+
+        assertNotNull(pojoDest.getChild1());
+        assertEquals("child1", pojoDest.getChild1().getName());
+        assertNull(pojoDest.getChild1().getChild1());
+        assertNull(pojoDest.getChild1().getChild2());
+
+        assertNotNull(pojoDest.getChild2());
+        assertEquals("child2", pojoDest.getChild2().getName());
+        assertNull(pojoDest.getChild2().getChild1());
+        assertNull(pojoDest.getChild2().getChild2());
+    }
+
+
+    @Test
+    public void testRecursiveObjectTableReading() {
+        byte[] data = new byte[1024];
+        RionObjectWriter ionObjectWriter = new RionObjectWriter(RecursiveArrayPojo.class);
+        RionObjectReader rionObjectReader = new RionObjectReader(RecursiveArrayPojo.class);
+
+        RecursiveArrayPojo pojoSource = new RecursiveArrayPojo();
+        pojoSource.setName("root");
+
+        RecursiveArrayPojo child1 = new RecursiveArrayPojo();
+        child1.setName("child1");
+
+        RecursiveArrayPojo child2 = new RecursiveArrayPojo();
+        child2.setName("child2");
+
+        pojoSource.setChildren(new RecursiveArrayPojo[]{child1, child2});
+
+        ionObjectWriter.writeObject(pojoSource, 2, data, 0);
+
+
+        RecursiveArrayPojo pojoDest = (RecursiveArrayPojo) rionObjectReader.read(data, 0);
+
+        assertNotNull(pojoDest);
+        assertEquals("root", pojoDest.getName());
+
+        assertNotNull(pojoDest.getChildren());
+        assertEquals(2, pojoDest.getChildren().length);
+
+        assertNotNull(pojoDest.getChildren()[0]);
+        assertEquals("child1", pojoDest.getChildren()[0].getName());
+        assertNull(pojoDest.getChildren()[0].getChildren());
+
+        assertNotNull(pojoDest.getChildren()[1]);
+        assertEquals("child2", pojoDest.getChildren()[1].getName());
+        assertNull(pojoDest.getChildren()[1].getChildren());
+
+
+    }
+}

--- a/src/test/java/com/nanosai/rionops/rion/read/object/IonObjectReaderTest.java
+++ b/src/test/java/com/nanosai/rionops/rion/read/object/IonObjectReaderTest.java
@@ -1,0 +1,548 @@
+package com.nanosai.rionops.rion.read.object;
+
+
+import com.nanosai.rionops.rion.pojo.*;
+import com.nanosai.rionops.rion.write.object.RionObjectWriter;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+/**
+ * Created by jjenkov on 05-11-2015.
+ */
+public class IonObjectReaderTest {
+
+
+    @Test
+    public void test() {
+        RionObjectWriter writer  = new RionObjectWriter(TestPojo.class);
+        RionObjectReader reader  = new RionObjectReader(TestPojo.class);
+
+        byte[] source = new byte[10 * 1024];
+
+        TestPojo sourcePojo = new TestPojo();
+        sourcePojo.field0 = false;
+        sourcePojo.field1 = 123;
+        sourcePojo.field2 = 456.456F;
+        sourcePojo.field3 = 456789.456789D;
+        sourcePojo.field4 = "abc";
+        sourcePojo.field5 = "987654321098765";
+
+        Calendar calendar = sourcePojo.field6;
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+        calendar.set(Calendar.YEAR , 2014);
+        calendar.set(Calendar.MONTH, 11);
+        calendar.set(Calendar.DAY_OF_MONTH, 31);
+        calendar.set(Calendar.HOUR_OF_DAY, 23);
+        calendar.set(Calendar.MINUTE, 59);
+        calendar.set(Calendar.SECOND, 59);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        TestPojo destPojo = null;
+
+        int length = writer.writeObject(sourcePojo, 2, source, 0);   //write object first
+
+        //todo fix error in TypedObjectReader related to reading compact keys
+
+        destPojo = (TestPojo) reader.read(source, 0);
+
+        assertEquals(false, destPojo.field0);
+        assertEquals(123, destPojo.field1);
+        assertEquals(456.456F, destPojo.field2, 0);
+        assertEquals("abc", destPojo.field4);
+        assertEquals("987654321098765", destPojo.field5);
+        assertEquals(calendar, destPojo.field6);
+    }
+
+
+    @Test
+    public void test_readInto() {
+        RionObjectWriter writer  = new RionObjectWriter(TestPojo.class);
+        RionObjectReader reader  = new RionObjectReader(TestPojo.class);
+
+        byte[] source = new byte[10 * 1024];
+
+        TestPojo sourcePojo = new TestPojo();
+        sourcePojo.field0 = false;
+        sourcePojo.field1 = 123;
+        sourcePojo.field2 = 456.456F;
+        sourcePojo.field3 = 456789.456789D;
+        sourcePojo.field4 = "abc";
+        sourcePojo.field5 = "987654321098765";
+
+        Calendar calendar = sourcePojo.field6;
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+        calendar.set(Calendar.YEAR , 2014);
+        calendar.set(Calendar.MONTH, 11);
+        calendar.set(Calendar.DAY_OF_MONTH, 31);
+        calendar.set(Calendar.HOUR_OF_DAY, 23);
+        calendar.set(Calendar.MINUTE, 59);
+        calendar.set(Calendar.SECOND, 59);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        TestPojo destPojo = null;
+
+        int length = writer.writeObject(sourcePojo, 2, source, 0);   //write object first
+
+        //todo fix error in TypedObjectReader related to reading compact keys
+
+        TestPojo destPojoInput = new TestPojo();
+        destPojo = (TestPojo) reader.read(source, 0, destPojoInput);
+
+        assertEquals(false, destPojo.field0);
+        assertEquals(123, destPojo.field1);
+        assertEquals(456.456F, destPojo.field2, 0);
+        assertEquals("abc", destPojo.field4);
+        assertEquals("987654321098765", destPojo.field5);
+        assertEquals(calendar, destPojo.field6);
+    }
+
+
+    @Test
+    public void testArrayDouble() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayDouble.class);
+        RionObjectReader reader = new RionObjectReader(PojoArrayDouble.class);
+
+        byte[] dest = new byte[100 * 1024];
+
+        PojoArrayDouble pojo = new PojoArrayDouble();
+        pojo.doubles = new double[]{1.1d, 4.4d, 9.9d, -1.1d};
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+
+        PojoArrayDouble pojo2 = (PojoArrayDouble) reader.read(dest, 0);
+
+        assertNotNull(pojo2) ;
+        assertNotNull(pojo2.doubles) ;
+        assertEquals(4, pojo2.doubles.length);
+        assertEquals(1.1d, pojo2.doubles[0], 0);
+        assertEquals(4.4d, pojo2.doubles[1], 0);
+        assertEquals(9.9d, pojo2.doubles[2], 0);
+        assertEquals(-1.1d, pojo2.doubles[3], 0);
+
+    }
+
+
+    @Test
+    public void testArrayFloat() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayFloat.class);
+        RionObjectReader reader = new RionObjectReader(PojoArrayFloat.class);
+
+        byte[] dest = new byte[100 * 1024];
+
+        PojoArrayFloat pojo = new PojoArrayFloat();
+        pojo.floats = new float[]{1.1f, 4.4f, 9.9f, -1.1f};
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+
+        PojoArrayFloat pojo2 = (PojoArrayFloat) reader.read(dest, 0);
+
+        assertNotNull(pojo2) ;
+        assertNotNull(pojo2.floats) ;
+        assertEquals(4, pojo2.floats.length);
+        assertEquals(1.1f, pojo2.floats[0], 0);
+        assertEquals(4.4f, pojo2.floats[1], 0);
+        assertEquals(9.9f, pojo2.floats[2], 0);
+        assertEquals(-1.1f, pojo2.floats[3], 0);
+
+    }
+
+
+    @Test
+    public void testArrayShort() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayShort.class);
+        RionObjectReader reader = new RionObjectReader(PojoArrayShort.class);
+
+        byte[] dest = new byte[100 * 1024];
+
+        PojoArrayShort pojo = new PojoArrayShort();
+        pojo.shorts = new short[]{1, 4, 9, -1};
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+
+        PojoArrayShort pojo2 = (PojoArrayShort) reader.read(dest, 0);
+
+        assertNotNull(pojo2) ;
+        assertNotNull(pojo2.shorts) ;
+        assertEquals(4, pojo2.shorts.length);
+        assertEquals(1, pojo2.shorts[0]);
+        assertEquals(4, pojo2.shorts[1]);
+        assertEquals(9, pojo2.shorts[2]);
+        assertEquals(-1, pojo2.shorts[3]);
+
+    }
+
+
+    @Test
+    public void testArrayInt() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayInt.class);
+        RionObjectReader reader = new RionObjectReader(PojoArrayInt.class);
+
+        byte[] dest = new byte[100 * 1024];
+
+        PojoArrayInt pojo = new PojoArrayInt();
+        pojo.ints = new int[]{1, 4, 9, -1};
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+
+        PojoArrayInt pojo2 = (PojoArrayInt) reader.read(dest, 0);
+
+        assertNotNull(pojo2) ;
+        assertNotNull(pojo2.ints) ;
+        assertEquals(4, pojo2.ints.length);
+        assertEquals(1, pojo2.ints[0]);
+        assertEquals(4, pojo2.ints[1]);
+        assertEquals(9, pojo2.ints[2]);
+        assertEquals(-1, pojo2.ints[3]);
+
+    }
+
+
+    @Test
+    public void testArrayLong() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayLong.class);
+        RionObjectReader reader = new RionObjectReader(PojoArrayLong.class);
+
+        byte[] dest = new byte[100 * 1024];
+
+        PojoArrayLong pojo = new PojoArrayLong();
+        pojo.longs = new long[]{1, 4, 9, -1};
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+
+        PojoArrayLong pojo2 = (PojoArrayLong) reader.read(dest, 0);
+
+        assertNotNull(pojo2) ;
+        assertNotNull(pojo2.longs) ;
+        assertEquals(4, pojo2.longs.length);
+        assertEquals(1, pojo2.longs[0]);
+        assertEquals(4, pojo2.longs[1]);
+        assertEquals(9, pojo2.longs[2]);
+        assertEquals(-1, pojo2.longs[3]);
+
+    }
+
+    @Test
+    public void testByteArrayField() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayByte.class);
+        RionObjectReader reader = new RionObjectReader(PojoArrayByte.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoArrayByte pojo = new PojoArrayByte();
+        pojo.bytes = new byte[]{ 1, 4, 9 };
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+
+        PojoArrayByte pojo2 = (PojoArrayByte) reader.read(dest, 0);
+
+        assertNotNull(pojo2) ;
+        assertNotNull(pojo2.bytes) ;
+        assertEquals(3, pojo2.bytes.length);
+        assertEquals(1, pojo2.bytes[0]);
+        assertEquals(4, pojo2.bytes[1]);
+        assertEquals(9, pojo2.bytes[2]);
+    }
+
+
+
+    @Test
+    public void testTableField() {
+        RionObjectWriter writer  = new RionObjectWriter(TestPojoArray.class);
+        RionObjectReader reader  = new RionObjectReader(TestPojoArray.class);
+
+        byte[] source = new byte[10 * 1024];
+
+        TestPojoArray sourcePojoArray = new TestPojoArray();
+
+        sourcePojoArray.testObjects    = new TestPojoArray.TestObject[3];
+        sourcePojoArray.testObjects[0] = new TestPojoArray.TestObject();
+        sourcePojoArray.testObjects[1] = new TestPojoArray.TestObject();
+        sourcePojoArray.testObjects[2] = new TestPojoArray.TestObject();
+
+        TestPojoArray destPojo         = new TestPojoArray();
+
+        int length = writer.writeObject(sourcePojoArray, 2, source, 0);
+
+        destPojo = (TestPojoArray) reader.read(source, 0);
+
+    }
+
+
+    @Test
+    public void testObjectField() {
+        RionObjectWriter writer = new RionObjectWriter(PojoWithPojo.class);
+        RionObjectReader reader = new RionObjectReader(PojoWithPojo.class);
+
+        byte[] source   = new byte[100 * 1024];
+
+        PojoWithPojo pojo = new PojoWithPojo();
+        pojo.field0.field0 = 10;
+        pojo.field0.field1 = 11;
+        pojo.field0.field2 = 12;
+        pojo.field0.field3 = 13;
+        pojo.field0.field4 = 14;
+        pojo.field0.field5 = 15;
+        pojo.field0.field6 = 16;
+        pojo.field0.field7 = 17;
+        pojo.field0.field8 = 18;
+        pojo.field0.field9 = 19;
+
+        int bytesWritten = writer.writeObject(pojo, 2, source, 0);
+
+        System.out.println("bytesWritten = " + bytesWritten);
+
+        PojoWithPojo pojo2 = (PojoWithPojo) reader.read(source, 0);
+
+        assertEquals(10, pojo2.field0.field0);
+        assertEquals(11, pojo2.field0.field1);
+        assertEquals(12, pojo2.field0.field2);
+        assertEquals(13, pojo2.field0.field3);
+        assertEquals(14, pojo2.field0.field4);
+        assertEquals(15, pojo2.field0.field5);
+        assertEquals(16, pojo2.field0.field6);
+        assertEquals(17, pojo2.field0.field7);
+        assertEquals(18, pojo2.field0.field8);
+        assertEquals(19, pojo2.field0.field9);
+
+    }
+
+
+    @Test
+    public void testReadWithConfigurator() {
+        RionObjectWriter writer = new RionObjectWriter(SmallPojo.class);
+        RionObjectReader reader = new RionObjectReader(SmallPojo.class);
+
+        SmallPojo sourcePojo = new SmallPojo();
+        sourcePojo.field0 = false;
+        sourcePojo.field1 = 999;
+        sourcePojo.field2 = 999.99f;
+
+        byte[] source   = new byte[100 * 1024];
+
+        writer.writeObject(sourcePojo, 2, source, 0);
+
+        SmallPojo readPojo = (SmallPojo) reader.read(source, 0);
+
+        assertEquals(false  , readPojo.field0);
+        assertEquals(999    , readPojo.field1);
+        assertEquals(999.99F, readPojo.field2, 0F);
+
+
+        RionObjectReader reader2 = new RionObjectReader(SmallPojo.class, config -> {
+            if("field2".equals(config.fieldName)){
+                config.include = false;
+            }
+        });
+
+        SmallPojo readPojo2 = (SmallPojo) reader2.read(source, 0);
+        assertEquals(false  , readPojo2.field0);
+        assertEquals(999    , readPojo2.field1);
+        assertEquals(123.12F, readPojo2.field2, 0F);  //value should not be bytesRead.
+
+
+        RionObjectWriter writer3 = new RionObjectWriter(SmallPojo.class, config -> {
+            if("field0".equals(config.fieldName)){
+                config.alias = "f0";
+            }
+        });
+
+        RionObjectReader reader3 = new RionObjectReader(SmallPojo.class, config -> {
+            if("field0".equals(config.fieldName)){
+                config.alias = "f0";
+            }
+        });
+
+
+        writer3.writeObject(sourcePojo, 2, source, 0);
+
+        SmallPojo readPojo3 = (SmallPojo) reader3.read(source, 0);
+
+        assertEquals(false  , readPojo3.field0);
+        assertEquals(999    , readPojo3.field1);
+        assertEquals(999.99F, readPojo3.field2, 0F);
+    }
+
+
+
+
+    @Test
+    public void testReadWithConfiguratorRecursively() {
+        RionObjectWriter writer = new RionObjectWriter(PojoWithPojo.class, fieldConfig -> {
+
+            assertNotNull(fieldConfig.field);
+
+            if(PojoWithPojo.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                }
+            }
+            if(Pojo10Int.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                } else if("field1".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f1";
+                }
+            }
+        });
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoWithPojo pojo = new PojoWithPojo();
+        pojo.field0.field0 = 10;
+        pojo.field0.field1 = 11;
+        pojo.field0.field2 = 12;
+        pojo.field0.field3 = 13;
+        pojo.field0.field4 = 14;
+        pojo.field0.field5 = 15;
+        pojo.field0.field6 = 16;
+        pojo.field0.field7 = 17;
+        pojo.field0.field8 = 18;
+        pojo.field0.field9 = 19;
+
+        int bytesWritten = writer.writeObject(pojo, 2, dest, 0);
+
+        System.out.println("bytesWritten = " + bytesWritten);
+
+
+        RionObjectReader reader = new RionObjectReader(PojoWithPojo.class, fieldConfig -> {
+            if(PojoWithPojo.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                }
+            }
+            if(Pojo10Int.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                } else if("field1".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f1";
+                } else if("field2".equals(fieldConfig.fieldName)){
+                    fieldConfig.include = false;
+                }
+            }
+        });
+
+        PojoWithPojo pojoRead = (PojoWithPojo) reader.read(dest, 0);
+
+        assertNotNull(pojoRead);
+        assertNotNull(pojoRead.field0);
+
+        assertEquals(10, pojoRead.field0.field0);
+        assertEquals(11, pojoRead.field0.field1);
+        assertEquals( 2, pojoRead.field0.field2);
+        assertEquals(13, pojoRead.field0.field3);
+        assertEquals(14, pojoRead.field0.field4);
+        assertEquals(15, pojoRead.field0.field5);
+        assertEquals(16, pojoRead.field0.field6);
+        assertEquals(17, pojoRead.field0.field7);
+        assertEquals(18, pojoRead.field0.field8);
+        assertEquals(19, pojoRead.field0.field9);
+    }
+
+
+    @Test
+    public void testReadWithConfiguratorOnTablesRecursively() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArray10Float.class, fieldConfig -> {
+
+            assertNotNull(fieldConfig.field);
+
+            if(PojoArray10Float.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                }
+            }
+            if(Pojo10Float.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                } else if("field1".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f1";
+                }
+            }
+        });
+
+        PojoArray10Float pojo = new PojoArray10Float(3);
+        pojo.pojos[0].field0 = 111.111f;
+        pojo.pojos[0].field2 = 222.222f; //this field is ignored in the reader, so in the bytesRead object it should have the default value.
+        pojo.pojos[0].field3 = 333.333f;
+
+        pojo.pojos[1].field0 = 444.444f;
+        pojo.pojos[1].field2 = 222.222f; //this field is ignored in the reader, so in the bytesRead object it should have the default value.
+        pojo.pojos[1].field3 = 555.555f;
+
+        pojo.pojos[2].field0 = 666.666f;
+        pojo.pojos[2].field2 = 222.222f; //this field is ignored in the reader, so in the bytesRead object it should have the default value.
+        pojo.pojos[2].field3 = 777.777f;
+
+
+        byte[] dest   = new byte[100 * 1024];
+
+        int bytesWritten = writer.writeObject(pojo, 2, dest, 0);
+        System.out.println("bytesWritten = " + bytesWritten);
+
+
+        RionObjectReader reader = new RionObjectReader(PojoArray10Float.class, fieldConfig -> {
+            if(PojoArray10Float.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                }
+//                System.out.println("Configurator applied to PojoArray10Float");
+            }
+            if(Pojo10Float.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                } else if("field1".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f1";
+                } else if("field2".equals(fieldConfig.fieldName)){
+                    fieldConfig.include = false;
+                }
+//                System.out.println("Configurator applied to Pojo10Float");
+            }
+        });
+
+
+        PojoArray10Float pojoRead = (PojoArray10Float) reader.read(dest, 0);
+
+        assertEquals(3, pojoRead.pojos.length);
+
+        assertEquals(111.111F     , pojoRead.pojos[0].field0, 0F);
+        assertEquals(12.12F       , pojoRead.pojos[0].field1, 0F);
+        assertEquals(123.123F     , pojoRead.pojos[0].field2, 0F);
+        assertEquals(333.333F     , pojoRead.pojos[0].field3, 0F);
+        assertEquals(12345.12345F , pojoRead.pojos[0].field4, 0F);
+        assertEquals(-1.1F        , pojoRead.pojos[0].field5, 0F);
+        assertEquals(-12.12F      , pojoRead.pojos[0].field6, 0F);
+        assertEquals(-123.123F    , pojoRead.pojos[0].field7, 0F);
+        assertEquals(-1234.1234F  , pojoRead.pojos[0].field8, 0F);
+        assertEquals(-12345.12345F, pojoRead.pojos[0].field9, 0F);
+
+        assertEquals(444.444F     , pojoRead.pojos[1].field0, 0F);
+        assertEquals(12.12F       , pojoRead.pojos[1].field1, 0F);
+        assertEquals(123.123F     , pojoRead.pojos[1].field2, 0F);
+        assertEquals(555.555F     , pojoRead.pojos[1].field3, 0F);
+        assertEquals(12345.12345F , pojoRead.pojos[1].field4, 0F);
+        assertEquals(-1.1F        , pojoRead.pojos[1].field5, 0F);
+        assertEquals(-12.12F      , pojoRead.pojos[1].field6, 0F);
+        assertEquals(-123.123F    , pojoRead.pojos[1].field7, 0F);
+        assertEquals(-1234.1234F  , pojoRead.pojos[1].field8, 0F);
+        assertEquals(-12345.12345F, pojoRead.pojos[1].field9, 0F);
+
+        assertEquals(666.666F     , pojoRead.pojos[2].field0, 0F);
+        assertEquals(12.12F       , pojoRead.pojos[2].field1, 0F);
+        assertEquals(123.123F     , pojoRead.pojos[2].field2, 0F);
+        assertEquals(777.777F     , pojoRead.pojos[2].field3, 0F);
+        assertEquals(12345.12345F , pojoRead.pojos[2].field4, 0F);
+        assertEquals(-1.1F        , pojoRead.pojos[2].field5, 0F);
+        assertEquals(-12.12F      , pojoRead.pojos[2].field6, 0F);
+        assertEquals(-123.123F    , pojoRead.pojos[2].field7, 0F);
+        assertEquals(-1234.1234F  , pojoRead.pojos[2].field8, 0F);
+        assertEquals(-12345.12345F, pojoRead.pojos[2].field9, 0F);
+
+    }
+
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/write/object/IonFieldWriterTests.java
+++ b/src/test/java/com/nanosai/rionops/rion/write/object/IonFieldWriterTests.java
@@ -1,0 +1,121 @@
+package com.nanosai.rionops.rion.write.object;
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class IonFieldWriterTests {
+
+    /*
+
+    @Test
+    public void testBooleanFieldWriter() throws NoSuchFieldException {
+        byte[] dest = new byte[10 * 1024];
+
+        Class testPojoClass = TestPojo.class;
+        Field boolean1Field1 = testPojoClass.getDeclaredField("boolean1");
+        RionFieldWriterBoolean writer1 = new RionFieldWriterBoolean(boolean1Field1);
+
+        TestPojo testPojo = new TestPojo();
+
+        assertEquals(11, writer1.writeKeyAndValueFields(testPojo, dest, 0, 2));
+        assertEquals((IapFieldTypes.KEY << 3 ) | 1, 255 & dest[0]);
+        assertEquals(  8, 255 & dest[1]);
+        assertEquals( 98, 255 & dest[2]);  //value of char 1 field
+        assertEquals(111, 255 & dest[3]);  //value of char 2 field
+        assertEquals(111, 255 & dest[4]);  //value of char 3 field
+        assertEquals(108, 255 & dest[5]);  //value of char 4 field
+        assertEquals(101, 255 & dest[6]);  //value of char 5 field
+        assertEquals( 97, 255 & dest[7]);  //value of char 6 field
+        assertEquals(110, 255 & dest[8]);  //value of char 7 field
+        assertEquals( 49, 255 & dest[9]);  //value of char 8 field
+
+
+        Field boolean1Field2 = testPojoClass.getDeclaredField("boolean2");
+        IapFieldWriterBoolean writer2 = new IapFieldWriterBoolean(boolean1Field2);
+
+        assertEquals(11, writer2.writeKeyAndValueFields(testPojo, dest, 11, 2));
+        assertEquals((IapFieldTypes.KEY << 3 ) | 1, 255 & dest[11]);
+        assertEquals(  8, 255 & dest[12]);
+        assertEquals( 98, 255 & dest[13]);  //value of char 1 field
+        assertEquals(111, 255 & dest[14]);  //value of char 2 field
+        assertEquals(111, 255 & dest[15]);  //value of char 3 field
+        assertEquals(108, 255 & dest[16]);  //value of char 4 field
+        assertEquals(101, 255 & dest[17]);  //value of char 5 field
+        assertEquals( 97, 255 & dest[18]);  //value of char 6 field
+        assertEquals(110, 255 & dest[19]);  //value of char 7 field
+        assertEquals( 50, 255 & dest[20]);  //value of char 8 field
+    }
+
+
+    @Test
+    public void testTableField() throws NoSuchFieldException {
+        byte[] dest = new byte[10 * 1024];
+
+        Class testPojoClass = TestPojoArray.class;
+        Field arrayField = testPojoClass.getDeclaredField("testObjects");
+        IapFieldWriterTable writer = new IapFieldWriterTable(arrayField);
+
+        TestPojoArray testPojo = new TestPojoArray();
+        testPojo.testObjects    = new TestPojoArray.TestObject[2];
+        testPojo.testObjects[0] = new TestPojoArray.TestObject();
+        testPojo.testObjects[1] = new TestPojoArray.TestObject();
+
+        int tableLength = writer.writeKeyAndValueFields(testPojo, dest, 0, 2);
+
+        //table sourceLength should be:
+        // key field : 1 + 1 + "testObjects" =  13
+
+
+        int index = 0;
+        assertEquals((IapFieldTypes.KEY   << 3) | 1, 255 & dest[index++]);
+        assertEquals(11, dest[index++]); //key sourceLength
+        assertEquals('t', dest[index++]);
+        assertEquals('e', dest[index++]);
+        assertEquals('s', dest[index++]);
+        assertEquals('t', dest[index++]);
+        assertEquals('O', dest[index++]);
+        assertEquals('b', dest[index++]);
+        assertEquals('j', dest[index++]);
+        assertEquals('e', dest[index++]);
+        assertEquals('c', dest[index++]);
+        assertEquals('t', dest[index++]);
+        assertEquals('s', dest[index++]);
+
+
+        // table lead byte + 2 sourceLength bytes = 3
+        // key field = 1 + 2 (id field) = 3
+        // 2 long fields of 1 lead byte + 1 sourceLength byte + 1 value byte = 2 x 3 = 6;
+        assertEquals((IapFieldTypes.TABLE << 3) | 2, 255 & dest[index++]);
+        assertEquals( 0, dest[index++]);
+        assertEquals(61, dest[index++]);   // 5 compact keys (3 bytes), 1 boolean, 1 short, 1 int, 1 long and 1 float field
+
+        assertEquals((IapFieldTypes.KEY_SHORT << 3) | 6, 255 & dest[index++]);
+        assertEquals('f', dest[index++]);
+        assertEquals('i', dest[index++]);
+        assertEquals('e', dest[index++]);
+        assertEquals('l', dest[index++]);
+        assertEquals('d', dest[index++]);
+        assertEquals('0', dest[index++]);
+
+        //todo insert tests for the rest of the fields in the table
+
+        */
+        /*
+        assertEquals((IapFieldTypes.SLONG << 3) | 1, 255 & dest[index++]);
+        assertEquals(  1, dest[index++]);
+        assertEquals(123, dest[index++]);
+
+        assertEquals((IapFieldTypes.SLONG << 3) | 1, 255 & dest[index++]);
+        assertEquals(  1, dest[index++]);
+        assertEquals(123, dest[index++]);
+
+        assertEquals(0, dest[index++]); //should be empty - no more written to byte array
+
+        */
+
+        //System.out.println("Done");
+
+    //}
+
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/write/object/IonObjectWriterRecursivePojoTests.java
+++ b/src/test/java/com/nanosai/rionops/rion/write/object/IonObjectWriterRecursivePojoTests.java
@@ -1,0 +1,259 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.pojo.RecursiveArrayPojo;
+import com.nanosai.rionops.rion.pojo.RecursivePojo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Created by jjenkov on 18/03/2017.
+ */
+public class IonObjectWriterRecursivePojoTests {
+
+
+    @Test
+    public void testWriteRecursivePojo() {
+        RionObjectWriter rionObjectWriter = new RionObjectWriter(RecursivePojo.class);
+
+        RionFieldWriterObject ionFieldWriterObject = (RionFieldWriterObject) rionObjectWriter.fieldWriters[1];
+
+        assertEquals(RionFieldWriterString.class, rionObjectWriter.fieldWriters[0].getClass());
+        assertEquals(RionFieldWriterObject.class, rionObjectWriter.fieldWriters[1].getClass());
+        assertSame(rionObjectWriter.fieldWriters[1], ionFieldWriterObject.fieldWriters[1]);
+
+        RecursivePojo root   = new RecursivePojo();
+        RecursivePojo child1 = new RecursivePojo();
+        RecursivePojo child2 = new RecursivePojo();
+
+        root.setName("root");
+        child1.setName("child1");
+        child2.setName("child2");
+
+        root.setChild1(child1);
+        root.setChild2(child2);
+
+        byte[] dest = new byte[1024];
+
+        rionObjectWriter.writeObject(root, 2, dest, 0);
+
+        int index = 0;
+        assertEquals(RionFieldTypes.OBJECT << 4 | 2, 255 & dest[index++]);
+        assertEquals(0, 255 & dest[index++]);
+        assertEquals(86, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 4, 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+        assertEquals('a', 255 & dest[index++]);
+        assertEquals('m', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.UTF_8_SHORT << 4 | 4, 255 & dest[index++]);
+        assertEquals('r', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('t', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+
+        assertEquals(RionFieldTypes.OBJECT << 4 | 2, 255 & dest[index++]);
+        assertEquals(0, 255 & dest[index++]);
+        assertEquals(28, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 4, 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+        assertEquals('a', 255 & dest[index++]);
+        assertEquals('m', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.UTF_8_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.OBJECT << 4 | 0, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('2', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.OBJECT << 4 | 0, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('2', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.OBJECT << 4 | 2, 255 & dest[index++]);
+        assertEquals(0, 255 & dest[index++]);
+        assertEquals(28, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 4, 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+        assertEquals('a', 255 & dest[index++]);
+        assertEquals('m', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.UTF_8_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('2', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.OBJECT << 4 | 0, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('2', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.OBJECT << 4 | 0, 255 & dest[index++]);
+
+    }
+
+
+    @Test
+    public void testWriteRecursiveArrayPojo() {
+        RionObjectWriter rionObjectWriter = new RionObjectWriter(RecursiveArrayPojo.class);
+
+        RionFieldWriterTable ionFieldWriterTable = (RionFieldWriterTable) rionObjectWriter.fieldWriters[1];
+
+        assertEquals(RionFieldWriterString.class, rionObjectWriter.fieldWriters[0].getClass());
+        assertEquals(RionFieldWriterTable.class, rionObjectWriter.fieldWriters[1].getClass());
+        assertSame(rionObjectWriter.fieldWriters[1], ionFieldWriterTable.fieldWritersForArrayType[1]);
+
+        RecursiveArrayPojo root   = new RecursiveArrayPojo();
+        RecursiveArrayPojo child1 = new RecursiveArrayPojo();
+        RecursiveArrayPojo child2 = new RecursiveArrayPojo();
+
+        root.setChildren(new RecursiveArrayPojo[2]);
+        root.getChildren()[0] = new RecursiveArrayPojo();
+        root.getChildren()[1] = new RecursiveArrayPojo();
+
+        root.setName("root");
+        root.getChildren()[0].setName("child1");
+        root.getChildren()[1].setName("child2");
+
+        byte[] dest = new byte[1024];
+
+        rionObjectWriter.writeObject(root, 2, dest, 0);
+
+        int index = 0;
+        assertEquals(RionFieldTypes.OBJECT << 4 | 2, 255 & dest[index++]);
+        assertEquals(0, 255 & dest[index++]);
+        assertEquals(54, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 4, 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+        assertEquals('a', 255 & dest[index++]);
+        assertEquals('m', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.UTF_8_SHORT << 4 | 4, 255 & dest[index++]);
+        assertEquals('r', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('t', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 8, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('r', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.TABLE << 4 | 2, 255 & dest[index++]);
+        assertEquals( 0, 255 & dest[index++]);
+        assertEquals(32, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.INT_POS << 4 | 1, 255 & dest[index++]);
+        assertEquals( 2, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 4, 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+        assertEquals('a', 255 & dest[index++]);
+        assertEquals('m', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.KEY_SHORT << 4 | 8, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('r', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.UTF_8_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.TABLE << 4 | 0, 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.UTF_8_SHORT << 4 | 6, 255 & dest[index++]);
+        assertEquals('c', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('2', 255 & dest[index++]);
+
+        assertEquals(RionFieldTypes.TABLE << 4 | 0, 255 & dest[index++]);
+
+
+
+
+
+    }
+
+
+}

--- a/src/test/java/com/nanosai/rionops/rion/write/object/IonObjectWriterTest.java
+++ b/src/test/java/com/nanosai/rionops/rion/write/object/IonObjectWriterTest.java
@@ -1,0 +1,1080 @@
+package com.nanosai.rionops.rion.write.object;
+
+
+import com.nanosai.rionops.rion.RionFieldTypes;
+import com.nanosai.rionops.rion.pojo.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+/**
+ * Created by jjenkov on 04-11-2015.
+ */
+public class IonObjectWriterTest {
+
+
+    @Test
+    public void test() {
+        RionObjectWriter writer = new RionObjectWriter(TestPojo.class);
+        byte[] dest   = new byte[1024];
+
+        TestPojo testPojo = new TestPojo();
+        Calendar calendar = testPojo.field6;
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+        calendar.set(Calendar.YEAR , 2014);
+        calendar.set(Calendar.MONTH, 11);
+        calendar.set(Calendar.DAY_OF_MONTH, 31);
+        calendar.set(Calendar.HOUR_OF_DAY, 23);
+        calendar.set(Calendar.MINUTE, 59);
+        calendar.set(Calendar.SECOND, 59);
+
+        writer.writeObject(testPojo, 2, dest, 0);
+
+        int index = 0;
+
+        assertEquals((RionFieldTypes.OBJECT << 4) | 2, 255 & dest[index++]);  //object field started - 194 = object field type << 3 | 2 (sourceLength sourceLength)
+        assertEquals(  0, 255 & dest[index++]);  //sourceLength of object - MSB
+        assertEquals(101, 255 & dest[index++]);  //sourceLength of object - LSB
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);   //lead byte of key field
+        assertEquals('f', 255 & dest[index++]);   //value of char 1 field
+        assertEquals('i', 255 & dest[index++]);   //value of char 2 field
+        assertEquals('e', 255 & dest[index++]);   //value of char 3 field
+        assertEquals('l', 255 & dest[index++]);   //value of char 4 field
+        assertEquals('d', 255 & dest[index++]);   //value of char 5 field
+        assertEquals('0', 255 & dest[index++]);  //value of char 6 field
+
+        assertEquals((RionFieldTypes.BOOLEAN << 4) | 1, 255 & dest[index++]);  //lead byte of boolean field
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);   //lead byte of key field
+        assertEquals('f', 255 & dest[index++]);   //value of char 1 field
+        assertEquals('i', 255 & dest[index++]);   //value of char 2 field
+        assertEquals('e', 255 & dest[index++]);   //value of char 3 field
+        assertEquals('l', 255 & dest[index++]);   //value of char 4 field
+        assertEquals('d', 255 & dest[index++]);   //value of char 5 field
+        assertEquals('1', 255 & dest[index++]);  //value of char 6 field
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 2, 255 & dest[index++]);  //lead byte of boolean field
+        assertEquals( 1234 >> 8 , 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 1234 & 255, 255 & dest[index++]);  //value of char 1 field
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);  //lead byte of compact key field
+        assertEquals('f', 255 & dest[index++]);   //value of char 1 field
+        assertEquals('i', 255 & dest[index++]);   //value of char 2 field
+        assertEquals('e', 255 & dest[index++]);   //value of char 3 field
+        assertEquals('l', 255 & dest[index++]);   //value of char 4 field
+        assertEquals('d', 255 & dest[index++]);   //value of char 5 field
+        assertEquals('2', 255 & dest[index++]);  //value of char 6 field
+
+        int floatBits = Float.floatToIntBits(123.12F);
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);  //lead byte of sshort field
+        assertEquals( 255 & (floatBits >> 24), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (floatBits >> 16), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (floatBits >>  8), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (floatBits)      , 255 & dest[index++]);  //value of char 1 field
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);  //value of char 2 field
+        assertEquals('f', 255 & dest[index++]);   //value of char 1 field
+        assertEquals('i', 255 & dest[index++]);   //value of char 2 field
+        assertEquals('e', 255 & dest[index++]);   //value of char 3 field
+        assertEquals('l', 255 & dest[index++]);   //value of char 4 field
+        assertEquals('d', 255 & dest[index++]);   //value of char 5 field
+        assertEquals('3', 255 & dest[index++]);  //value of char 6 field
+
+        long longBits = Double.doubleToLongBits(123456.1234D);
+        assertEquals((RionFieldTypes.FLOAT << 4) | 8, 255 & dest[index++]);  //lead byte of sint field
+        assertEquals( 255 & (longBits >> 56), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (longBits >> 48), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (longBits >> 40), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (longBits >> 32), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (longBits >> 24), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (longBits >> 16), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (longBits >>  8), 255 & dest[index++]);  //value of char 1 field
+        assertEquals( 255 & (longBits)      , 255 & dest[index++]);  //value of char 1 field
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);  //value of char 2 field
+        assertEquals('f', 255 & dest[index++]);   //value of char 1 field
+        assertEquals('i', 255 & dest[index++]);   //value of char 2 field
+        assertEquals('e', 255 & dest[index++]);   //value of char 3 field
+        assertEquals('l', 255 & dest[index++]);   //value of char 4 field
+        assertEquals('d', 255 & dest[index++]);   //value of char 5 field
+        assertEquals('4', 255 & dest[index++]);  //value of char 6 field
+
+        assertEquals((RionFieldTypes.UTF_8_SHORT << 4) | 7, 255 & dest[index++]);  //lead byte of long field
+        assertEquals('a', 255 & dest[index++]);  //value of long field
+        assertEquals('b', 255 & dest[index++]);  //value of long field
+        assertEquals('c', 255 & dest[index++]);  //value of long field
+        assertEquals('d', 255 & dest[index++]);  //value of long field
+        assertEquals('e', 255 & dest[index++]);  //value of long field
+        assertEquals('f', 255 & dest[index++]);  //value of long field
+        assertEquals('g', 255 & dest[index++]);  //value of long field
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);   //lead byte of key field
+        assertEquals('f', 255 & dest[index++]);   //value of char 1 field
+        assertEquals('i', 255 & dest[index++]);   //value of char 2 field
+        assertEquals('e', 255 & dest[index++]);   //value of char 3 field
+        assertEquals('l', 255 & dest[index++]);   //value of char 4 field
+        assertEquals('d', 255 & dest[index++]);   //value of char 5 field
+        assertEquals('5', 255 & dest[index++]);  //value of char 6 field
+
+
+        assertEquals((RionFieldTypes.UTF_8 << 4) | 1, 255 & dest[index++]);  //lead byte of long field
+        assertEquals( 16, 255 & dest[index++]);  //value of long field
+        assertEquals('0', 255 & dest[index++]);  //value of long field
+        assertEquals('1', 255 & dest[index++]);  //value of long field
+        assertEquals('2', 255 & dest[index++]);  //value of long field
+        assertEquals('3', 255 & dest[index++]);  //value of long field
+        assertEquals('4', 255 & dest[index++]);  //value of long field
+        assertEquals('5', 255 & dest[index++]);  //value of long field
+        assertEquals('6', 255 & dest[index++]);  //value of long field
+        assertEquals('7', 255 & dest[index++]);  //value of long field
+        assertEquals('8', 255 & dest[index++]);  //value of long field
+        assertEquals('9', 255 & dest[index++]);  //value of long field
+        assertEquals('0', 255 & dest[index++]);  //value of long field
+        assertEquals('1', 255 & dest[index++]);  //value of long field
+        assertEquals('2', 255 & dest[index++]);  //value of long field
+        assertEquals('3', 255 & dest[index++]);  //value of long field
+        assertEquals('4', 255 & dest[index++]);  //value of long field
+        assertEquals('5', 255 & dest[index++]);  //value of long field
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);   //lead byte of key field
+        assertEquals('f', 255 & dest[index++]);   //value of char 1 field
+        assertEquals('i', 255 & dest[index++]);   //value of char 2 field
+        assertEquals('e', 255 & dest[index++]);   //value of char 3 field
+        assertEquals('l', 255 & dest[index++]);   //value of char 4 field
+        assertEquals('d', 255 & dest[index++]);   //value of char 5 field
+        assertEquals('6', 255 & dest[index++]);  //value of char 6 field
+
+        assertEquals((RionFieldTypes.UTC_DATE_TIME << 4) | 7, 255 & dest[index++]);  //lead byte of long field
+        assertEquals(2014 >> 8 , 255 & dest[index++]);
+        assertEquals(2014 & 255, 255 & dest[index++]);
+        assertEquals( 12, 255 & dest[index++]);
+        assertEquals( 31, 255 & dest[index++]);
+        assertEquals( 23, 255 & dest[index++]);
+        assertEquals( 59, 255 & dest[index++]);
+        assertEquals( 59, 255 & dest[index++]);
+
+
+    }
+
+
+    @Test
+    public void testPojoArrayDouble() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayDouble.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoArrayDouble pojo = new PojoArrayDouble();
+        pojo.doubles = new double[]{ 1.1d, 4.4d, 9.9d, -1.1d };
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+        assertEquals(50, bytesWritten);
+        int index = 0;
+        assertEquals((RionFieldTypes.OBJECT << 4) | 1, 255 & dest[index++]);
+        assertEquals(48, 255 & dest[index++]);
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 7, 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('u', 255 & dest[index++]);
+        assertEquals('b', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('s', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.ARRAY << 4) | 1, 255 & dest[index++]);
+        assertEquals(38, 255 & dest[index++]);
+
+        //array element count
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 8, 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(1.1d) >> 56), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(1.1d) >> 48), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(1.1d) >> 40), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(1.1d) >> 32), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(1.1d) >> 24), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(1.1d) >> 16), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(1.1d) >>  8), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(1.1d)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 8, 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(4.4d) >> 56), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(4.4d) >> 48), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(4.4d) >> 40), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(4.4d) >> 32), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(4.4d) >> 24), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(4.4d) >> 16), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(4.4d) >>  8), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(4.4d)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 8, 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(9.9d) >> 56), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(9.9d) >> 48), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(9.9d) >> 40), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(9.9d) >> 32), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(9.9d) >> 24), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(9.9d) >> 16), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(9.9d) >>  8), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(9.9d)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 8, 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(-1.1d) >> 56), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(-1.1d) >> 48), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(-1.1d) >> 40), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(-1.1d) >> 32), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(-1.1d) >> 24), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(-1.1d) >> 16), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(-1.1d) >>  8), 255 & dest[index++]);
+        assertEquals( 255 & (Double.doubleToLongBits(-1.1d)      ), 255 & dest[index++]);
+    }
+
+
+    @Test
+    public void testPojoArrayFloat() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayFloat.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoArrayFloat pojo = new PojoArrayFloat();
+        pojo.floats = new float[]{ 1.1f, 4.4f, 9.9f, -1.1f };
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+        assertEquals(33, bytesWritten);
+        int index = 0;
+        assertEquals((RionFieldTypes.OBJECT << 4) | 1, 255 & dest[index++]);
+        assertEquals(31, 255 & dest[index++]);
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('a', 255 & dest[index++]);
+        assertEquals('t', 255 & dest[index++]);
+        assertEquals('s', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.ARRAY << 4) | 1, 255 & dest[index++]);
+        assertEquals(22, 255 & dest[index++]);
+
+        //array element count
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(1.1f) >> 24), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(1.1f) >> 16), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(1.1f) >>  8), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(1.1f)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(4.4f) >> 24), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(4.4f) >> 16), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(4.4f) >>  8), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(4.4f)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(9.9f) >> 24), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(9.9f) >> 16), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(9.9f) >>  8), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(9.9f)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(-1.1f) >> 24), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(-1.1f) >> 16), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(-1.1f) >>  8), 255 & dest[index++]);
+        assertEquals( 255 & (Float.floatToIntBits(-1.1f)      ), 255 & dest[index++]);
+    }
+
+
+    @Test
+    public void testPojoArrayShort() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayShort.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoArrayShort pojo = new PojoArrayShort();
+        pojo.shorts = new short[]{ 1, 4, 9, -1 };
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+        assertEquals(21, bytesWritten);
+        int index = 0;
+        assertEquals((RionFieldTypes.OBJECT << 4) | 1, 255 & dest[index++]);
+        assertEquals(19, 255 & dest[index++]);
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('s', 255 & dest[index++]);
+        assertEquals('h', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('r', 255 & dest[index++]);
+        assertEquals('t', 255 & dest[index++]);
+        assertEquals('s', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.ARRAY << 4) | 1, 255 & dest[index++]);
+        assertEquals(10, 255 & dest[index++]);
+
+        //array element count
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 1, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 9, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_NEG << 4) | 1, 255 & dest[index++]);
+        assertEquals( 0, 255 & dest[index++]);
+    }
+
+
+    @Test
+    public void testPojoArrayInt() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayInt.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoArrayInt pojo = new PojoArrayInt();
+        pojo.ints = new int[]{ 1, 4, 9, -1 };
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+        assertEquals(19, bytesWritten);
+        int index = 0;
+        assertEquals((RionFieldTypes.OBJECT << 4) | 1, 255 & dest[index++]);
+        assertEquals(17, 255 & dest[index++]);
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 4, 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+        assertEquals('t', 255 & dest[index++]);
+        assertEquals('s', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.ARRAY << 4) | 1, 255 & dest[index++]);
+        assertEquals(10, 255 & dest[index++]);
+
+        //array element count
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 1, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 9, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_NEG << 4) | 1, 255 & dest[index++]);
+        assertEquals( 0, 255 & dest[index++]);
+    }
+
+
+    @Test
+    public void testPojoArrayLong() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayLong.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoArrayLong pojo = new PojoArrayLong();
+        pojo.longs = new long[]{ 1, 4, 9, -1 };
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+        assertEquals(20, bytesWritten);
+        int index = 0;
+        assertEquals((RionFieldTypes.OBJECT << 4) | 1, 255 & dest[index++]);
+        assertEquals( 18, 255 & dest[index++]);
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 5, 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('n', 255 & dest[index++]);
+        assertEquals('g', 255 & dest[index++]);
+        assertEquals('s', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.ARRAY << 4) | 1, 255 & dest[index++]);
+        assertEquals(10, 255 & dest[index++]);
+
+        //array element count
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 1, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 9, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_NEG << 4) | 1, 255 & dest[index++]);
+        assertEquals( 0, 255 & dest[index++]);
+
+
+    }
+
+    @Test
+    public void testPojoArrayByte() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArrayByte.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoArrayByte pojo = new PojoArrayByte();
+        pojo.bytes = new byte[]{ 1, 4, 9 };
+
+        int bytesWritten = writer.writeObject(pojo, 1, dest, 0);
+
+        int index  = 0;
+        assertEquals(13, bytesWritten);
+        assertEquals((RionFieldTypes.OBJECT << 4) | 1, 255 & dest[index++]);
+        assertEquals( 11, 255 & dest[index++]);
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 5, 255 & dest[index++]);
+        assertEquals('b', 255 & dest[index++]);
+        assertEquals('y', 255 & dest[index++]);
+        assertEquals('t', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('s', 255 & dest[index++]);
+        assertEquals((RionFieldTypes.BYTES << 4) | 1, 255 & dest[index++]);
+        assertEquals( 3, 255 & dest[index++]);
+        assertEquals( 1, 255 & dest[index++]);
+        assertEquals( 4, 255 & dest[index++]);
+        assertEquals( 9, 255 & dest[index++]);
+
+
+    }
+
+
+    @Test
+    public void testPojoArray10Float() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArray10Float.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoArray10Float pojoArray10 = new PojoArray10Float(10);
+
+        int length = writer.writeObject(pojoArray10, 2, dest, 0);
+        System.out.println("sourceLength = " + length);
+
+    }
+
+
+    @Test
+    public void testPojoWithPojo() {
+        RionObjectWriter writer = new RionObjectWriter(PojoWithPojo.class);
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoWithPojo pojo = new PojoWithPojo();
+
+        int bytesWritten = writer.writeObject(pojo, 2, dest, 0);
+
+        System.out.println("bytesWritten = " + bytesWritten);
+
+        int index = 0;
+        assertEquals((RionFieldTypes.OBJECT << 4) | 2, 255 & dest[index++]);
+        assertEquals(   0, 255 & dest[index++]);
+        assertEquals( 100, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('0', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.OBJECT    << 4) | 2, 255 & dest[index++]);
+        assertEquals(   0, 255 & dest[index++]);
+        assertEquals(  90, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('0', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   0, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   1, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('2', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   2, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('3', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   3, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('4', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   4, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('5', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   5, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('6', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   6, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('7', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   7, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('8', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   8, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('9', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS    << 4) | 1, 255 & dest[index++]);
+        assertEquals(   9, 255 & dest[index++]);
+    }
+
+
+
+    @Test
+    public void testConfigurator() {
+        RionObjectWriter writer = new RionObjectWriter(SmallPojo.class, fieldConfig -> {
+            if("field0".equals(fieldConfig.fieldName)){
+                fieldConfig.alias = "f0";
+            } else if("field1".equals(fieldConfig.fieldName)){
+                fieldConfig.alias = "f1";
+            } else if("field2".equals(fieldConfig.fieldName)){
+                fieldConfig.include = false;
+            }
+        });
+
+        byte[] dest   = new byte[100 * 1024];
+
+        SmallPojo pojo = new SmallPojo();
+
+        int bytesWritten = writer.writeObject(pojo, 2, dest, 0);
+
+        System.out.println("bytesWritten = " + bytesWritten);
+
+        int index = 0;
+
+        assertEquals((RionFieldTypes.OBJECT << 4) | 2, 255 & dest[index++]);
+        assertEquals(   0, 255 & dest[index++]);
+        assertEquals(  10, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 2, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('0', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.BOOLEAN << 4) | 1, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 2, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 2, 255 & dest[index++]);
+        assertEquals( 1234 >> 8 , 255 & dest[index++]);
+        assertEquals( 1234 & 255, 255 & dest[index++]);
+
+    }
+
+
+    @Test
+    public void testConfiguratorRecursively() {
+        RionObjectWriter writer = new RionObjectWriter(PojoWithPojo.class, fieldConfig -> {
+
+            assertNotNull(fieldConfig.field);
+
+            if(PojoWithPojo.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                }
+            }
+            if(Pojo10Int.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                } else if("field1".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f1";
+                } else if("field2".equals(fieldConfig.fieldName)){
+                    fieldConfig.include = false;
+                }
+            }
+        });
+
+        byte[] dest   = new byte[100 * 1024];
+
+        PojoWithPojo pojo = new PojoWithPojo();
+        pojo.field0.field0 = 10;
+        pojo.field0.field1 = 11;
+        pojo.field0.field2 = 12;
+        pojo.field0.field3 = 13;
+        pojo.field0.field4 = 14;
+        pojo.field0.field5 = 15;
+        pojo.field0.field6 = 16;
+        pojo.field0.field7 = 17;
+        pojo.field0.field8 = 18;
+        pojo.field0.field9 = 19;
+
+        int bytesWritten = writer.writeObject(pojo, 2, dest, 0);
+
+        System.out.println("bytesWritten = " + bytesWritten);
+
+        int index = 0;
+        assertEquals((RionFieldTypes.OBJECT << 4) | 2, 255 & dest[index++]);
+        assertEquals(   0, 255 & dest[index++]);
+        assertEquals(  79, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 2, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('0', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.OBJECT << 4) | 2, 255 & dest[index++]);
+        assertEquals(   0, 255 & dest[index++]);
+        assertEquals(  73, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 2, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('0', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 10, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 2, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 11, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('3', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 13, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('4', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 14, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('5', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 15, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('6', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 16, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('7', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 17, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('8', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 18, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('9', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals( 19, 255 & dest[index++]);
+    }
+
+
+    @Test
+    public void testConfiguratorOnTablesRecursively() {
+        RionObjectWriter writer = new RionObjectWriter(PojoArray10Float.class, fieldConfig -> {
+
+            assertNotNull(fieldConfig.field);
+
+            if(PojoArray10Float.class.equals(fieldConfig.field.getDeclaringClass())){
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                }
+                //System.out.println("Configurator applied to PojoArray10Float");
+            }
+            if(Pojo10Float.class.equals(fieldConfig.field.getDeclaringClass())){
+                //System.out.println("Configurator applied to Pojo10Float");
+                if("field0".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f0";
+                } else if("field1".equals(fieldConfig.fieldName)){
+                    fieldConfig.alias = "f1";
+                } else if("field2".equals(fieldConfig.fieldName)){
+                    fieldConfig.include = false;
+                }
+            }
+        });
+
+        PojoArray10Float pojo = new PojoArray10Float(3);
+
+        byte[] dest   = new byte[100 * 1024];
+        int bytesWritten = writer.writeObject(pojo, 2, dest, 0);
+        System.out.println("bytesWritten = " + bytesWritten);
+
+        int index = 0;
+        assertEquals((RionFieldTypes.OBJECT << 4) | 2, 255 & dest[index++]);
+        assertEquals(   0, 255 & dest[index++]);
+        assertEquals( 201, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 5, 255 & dest[index++]);
+        assertEquals('p', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('j', 255 & dest[index++]);
+        assertEquals('o', 255 & dest[index++]);
+        assertEquals('s', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.TABLE << 4) | 2, 255 & dest[index++]);
+        assertEquals(   0, 255 & dest[index++]);
+        assertEquals( 192, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.INT_POS << 4) | 1, 255 & dest[index++]);
+        assertEquals(   3, 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 2, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('0', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 2, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('1', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('3', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('4', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('5', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('6', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('7', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('8', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.KEY_SHORT << 4) | 6, 255 & dest[index++]);
+        assertEquals('f', 255 & dest[index++]);
+        assertEquals('i', 255 & dest[index++]);
+        assertEquals('e', 255 & dest[index++]);
+        assertEquals('l', 255 & dest[index++]);
+        assertEquals('d', 255 & dest[index++]);
+        assertEquals('9', 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F)      ), 255 & dest[index++]);
+
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F)      ), 255 & dest[index++]);
+
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1.1F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12.12F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(1234.1234F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(12345.12345F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1.1F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12.12F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-123.123F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-1234.1234F)      ), 255 & dest[index++]);
+
+        assertEquals((RionFieldTypes.FLOAT << 4) | 4, 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >> 24), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >> 16), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F) >>  8), 255 & dest[index++]);
+        assertEquals(255 & (Float.floatToIntBits(-12345.12345F)      ), 255 & dest[index++]);
+
+
+    }
+
+
+
+
+
+}


### PR DESCRIPTION
This branch adds a RionObjectWriter and RionObjectReader which can be used to write Java objects (POJOs) into RION, and read RION into Java objects. This can be very useful in some situations, where convenience is more important than maximum performance.