### PR TITLE
Null support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ the next section.
 
 | Version | Java Version | Change |
 |---------|--------------|--------|
+| 0.9.0   | Java 8+      | Improved support for writing null fields in RionWriter. Bug fix of RionWriter.writeUtf8() which serialized empty string as UTF-8-Short null - not UTF-8 with length 0. |
 | 0.8.0   | Java 8+      | RionObjectWriterBuilder and RionObjectReaderBuilder classes added. |
 | 0.7.0   | Java 8+      | RionObjectWriter and RionObjectReader + support classes added. |
 | 0.6.0   | Java 8+      | RionToHexConverter added. Minor enhancements to RionWriter for writing Array and Table fields. |

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ the next section.
 
 | Version | Java Version | Change |
 |---------|--------------|--------|
-| 0.9.0   | Java 8+      | Improved support for writing null fields in RionWriter. Bug fix of RionWriter.writeUtf8() which serialized empty string as UTF-8-Short null - not UTF-8 with length 0. |
+| 0.9.0   | Java 8+      | Improved support for writing null fields in RionWriter. Bug fix of RionWriter.writeUtf8() which serialized empty string as UTF-8-Short null - not UTF-8 with length 0 (issue #14). |
 | 0.8.0   | Java 8+      | RionObjectWriterBuilder and RionObjectReaderBuilder classes added. |
 | 0.7.0   | Java 8+      | RionObjectWriter and RionObjectReader + support classes added. |
 | 0.6.0   | Java 8+      | RionToHexConverter added. Minor enhancements to RionWriter for writing Array and Table fields. |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nanosai</groupId>
     <artifactId>rion-ops</artifactId>
-    <version>0.8.0</version>
+    <version>0.9.0</version>
     <packaging>jar</packaging>
 
     <name>RION Ops for Java</name>

--- a/src/main/java/com/nanosai/rionops/rion/read/RionReader.java
+++ b/src/main/java/com/nanosai/rionops/rion/read/RionReader.java
@@ -189,6 +189,10 @@ public class RionReader {
         parse(); //
     }
 
+    public boolean isNull(){
+        return this.fieldLengthLength == 0;
+    }
+
 
     public int readBytes(byte[] dest){
         if(this.fieldLengthLength == 0) return 0;

--- a/src/main/java/com/nanosai/rionops/rion/write/RionWriter.java
+++ b/src/main/java/com/nanosai/rionops/rion/write/RionWriter.java
@@ -104,6 +104,10 @@ public class RionWriter {
         this.index += sourceLength;
     }
 
+    public void writeBytesNull(){
+        this.dest[this.index++] = (byte) (0xFF & (RionFieldTypes.BYTES << 4)); //lengthLength = 0 means null value
+    }
+
     public void writeBoolean(boolean value){
         if(value){
             this.dest[this.index++] = (byte) (0xFF & ((RionFieldTypes.BOOLEAN << 4) | 1));
@@ -122,6 +126,10 @@ public class RionWriter {
         } else {
             this.dest[this.index++] = (byte) (0xFF & ((RionFieldTypes.BOOLEAN << 4) | 2));
         }
+    }
+
+    public void writeBooleanNull() {
+        this.dest[this.index++] = (byte) (0xFF & ((RionFieldTypes.BOOLEAN << 4) | 0));
     }
 
     public void writeInt64(long value){
@@ -161,6 +169,10 @@ public class RionWriter {
         }
     }
 
+    public void writeInt64Null() {
+        dest[index++] = (byte) (0xFF & (RionFieldTypes.INT_POS << 4));
+    }
+
     public void writeFloat32(float value){
         int intBits = Float.floatToIntBits(value);
 
@@ -184,7 +196,6 @@ public class RionWriter {
         for(int i=(4-1)*8; i >= 0; i-=8){
             this.dest[this.index++] = (byte) (0xFF & (intBits >> i));
         }
-
     }
 
     public void writeFloat64(double value){
@@ -212,6 +223,10 @@ public class RionWriter {
         }
     }
 
+    public void writeFloatNull(){
+        this.dest[this.index++] = (byte) (0xFF & (RionFieldTypes.FLOAT << 4));
+    }
+
     public void writeUtf8(String value){
         if(value == null){
             this.dest[this.index++] = (byte) (0xFF & (RionFieldTypes.UTF_8 << 4));
@@ -229,7 +244,7 @@ public class RionWriter {
 
         int length         = utf8Bytes.length;
 
-        if(length <=15){
+        if(length > 0 &&  length <=15){
             this.dest[this.index++] = (byte) (0xFF & ((RionFieldTypes.UTF_8_SHORT << 4) | length));
             System.arraycopy(utf8Bytes, 0, this.dest, this.index, length);
             this.index += length;
@@ -244,7 +259,6 @@ public class RionWriter {
             System.arraycopy(utf8Bytes, 0, this.dest, this.index, length);
             this.index += length;
         }
-
     }
 
     public void writeUtf8(byte[] value){
@@ -294,7 +308,10 @@ public class RionWriter {
             System.arraycopy(source, sourceOffset, this.dest, this.index, sourceLength);
             this.index += sourceLength;
         }
+    }
 
+    public void writeUtf8Null() {
+        this.dest[this.index++] = (byte) (0xFF & (RionFieldTypes.UTF_8 << 4));
     }
 
     public void writeUtc(Calendar dateTime, int length){
@@ -335,8 +352,16 @@ public class RionWriter {
         dest[this.index++] = (byte) (0xFF & (millis));
 
         return;
-
     }
+
+    public void writeUtcNull(){
+        dest[this.index++] = (byte) (0xFF & (RionFieldTypes.UTC_DATE_TIME << 4));
+    }
+
+    public void writeObjectNull() {
+        dest[this.index++] = (byte) (0xFF & (RionFieldTypes.OBJECT << 4));
+    }
+
 
     public void writeObjectBegin(int lengthLength){
         this.dest[this.index++] = (byte) (0xFF & ((RionFieldTypes.OBJECT << 4) | lengthLength));
@@ -367,6 +392,12 @@ public class RionWriter {
             dest[objectStartIndex++] = (byte) (0xFF & (length >> i));
         }
     }
+
+    public void writeTableNull() {
+        dest[this.index++] = (byte) (0xFF & (RionFieldTypes.TABLE << 4));
+    }
+
+
 
     public void writeTableBegin(int lengthLength){
         this.dest[this.index++] = (byte) (0xFF & ((RionFieldTypes.TABLE << 4) | lengthLength));
@@ -427,6 +458,10 @@ public class RionWriter {
         for(int i=(lengthLength-1)*8; i >= 0; i-=8){
             dest[objectStartIndex++] = (byte) (0xFF & (elementCount >> i));
         }
+    }
+
+    public void writeArrayNull() {
+        dest[this.index++] = (byte) (0xFF & (RionFieldTypes.ARRAY << 4));
     }
 
     public void writeArrayBegin(int lengthLength){
@@ -540,6 +575,9 @@ public class RionWriter {
         }
     }
 
+    public void writeKeyNull() {
+        this.dest[this.index++] = (byte) (0xFF & (RionFieldTypes.KEY << 4));
+    }
 
     public void writeKey(String value){
         if(value == null){
@@ -735,6 +773,8 @@ public class RionWriter {
     /*
     Extended field types
     */
+
+    @Deprecated
     public void writeElementCount(long elementCount){
         int lengthLength = byteLengthOfInt64Value(elementCount);
         this.dest[this.index++] = (byte) (0xFF & ((RionFieldTypes.EXTENDED << 4) | lengthLength));

--- a/src/test/java/com/nanosai/rionops/rion/read/RionReaderTest.java
+++ b/src/test/java/com/nanosai/rionops/rion/read/RionReaderTest.java
@@ -16,6 +16,175 @@ public class RionReaderTest {
 
     RionReader reader = new RionReader();
 
+
+    @Test
+    public void testWriteReadNullFields() {
+        byte[] source = new byte[10 * 1024];
+
+        RionWriter writer = new RionWriter();
+        writer.setDestination(source, 0);
+
+        writer.writeBytesNull();
+        writer.writeBytes(null);
+        writer.writeBytes( new byte[]{} );
+        writer.writeBytes( new byte[]{1,2,3} );
+
+        writer.writeBooleanNull();
+        writer.writeBooleanObj(null);
+        writer.writeBooleanObj(new Boolean(true));
+        writer.writeBoolean(true);
+
+        writer.writeInt64Null();
+        writer.writeInt64Obj(null);
+        writer.writeInt64Obj(new Long(123));
+        writer.writeInt64(123);
+
+        writer.writeFloatNull();
+        writer.writeFloat32Obj (null);
+        writer.writeFloat64Obj (null);
+        writer.writeFloat32Obj (new Float(123.45));
+        writer.writeFloat64Obj (new Double(123.45));
+
+        writer.writeUtf8Null();
+        writer.writeUtf8 ((String) null);
+        writer.writeUtf8 ("" );
+        writer.writeUtf8 ("123" );
+
+        writer.writeUtcNull();
+        writer.writeUtc (null, 9);
+        writer.writeUtc (new GregorianCalendar(), 9 );
+
+        writer.writeArrayNull ();
+        writer.writeTableNull ();
+        writer.writeObjectNull ();
+
+        RionReader reader = new RionReader(source, 0, writer.index);
+
+        //Bytes fields
+        reader.nextParse();
+        assertEquals(RionFieldTypes.BYTES, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.BYTES, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.BYTES, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.BYTES, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        //Boolean fields
+        reader.nextParse();
+        assertEquals(RionFieldTypes.BOOLEAN, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.BOOLEAN, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.BOOLEAN, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.BOOLEAN, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        //Int fields
+        reader.nextParse();
+        assertEquals(RionFieldTypes.INT_POS, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.INT_POS, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.INT_POS, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.INT_POS, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        //Float fields
+        reader.nextParse();
+        assertEquals(RionFieldTypes.FLOAT, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.FLOAT, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.FLOAT, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.FLOAT, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.FLOAT, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        //UTF-8 fields
+        reader.nextParse();
+        assertEquals(RionFieldTypes.UTF_8, reader.fieldType);
+        assertTrue(reader.isNull());
+        assertNull(reader.readUtf8String());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.UTF_8, reader.fieldType);
+        assertTrue(reader.isNull());
+        assertNull(reader.readUtf8String());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.UTF_8, reader.fieldType);
+        assertFalse(reader.isNull());
+        assertEquals("", reader.readUtf8String());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.UTF_8_SHORT, reader.fieldType);
+        assertFalse(reader.isNull());
+        assertEquals("123", reader.readUtf8String());
+
+        //UTC fields
+        reader.nextParse();
+        assertEquals(RionFieldTypes.UTC_DATE_TIME, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.UTC_DATE_TIME, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        reader.nextParse();
+        assertEquals(RionFieldTypes.UTC_DATE_TIME, reader.fieldType);
+        assertFalse(reader.isNull());
+
+        //Array field
+        reader.nextParse();
+        assertEquals(RionFieldTypes.ARRAY, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        //Table field
+        reader.nextParse();
+        assertEquals(RionFieldTypes.TABLE, reader.fieldType);
+        assertTrue(reader.isNull());
+
+        //Table field
+        reader.nextParse();
+        assertEquals(RionFieldTypes.OBJECT, reader.fieldType);
+        assertTrue(reader.isNull());
+
+    }
+
+
+
     @Test
     public void testSetSource_byteArray() {
         byte[] source = new byte[10 * 1024];


### PR DESCRIPTION
Improved support for writing null fields in RionWriter, a method for checking for null field values in RionReader (.isNull()), and a bug fix of serializing empty strings - which were serialized as UTF-8-Short null instead of zero length UTF-8 fields.